### PR TITLE
Refine layout width handling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -419,11 +419,31 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Main content area alignment fix */
 .main-content-area {
-  width: 100%;
-  max-width: none;
+  max-width: 100%;
   margin: 0;
   padding: 1rem 1.5rem;
   box-sizing: border-box;
+}
+
+.main-content-area > * {
+  max-width: 100%;
+}
+
+.main-content-area :where(.tool-content) {
+  max-width: 100%;
+}
+
+.main-content-area :where(.bg-card) {
+  max-width: 100%;
+}
+
+.main-content-area :where(.card) {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.main-content-area :where(.card > *) {
+  min-width: 0;
 }
 
 @media (min-width: 768px) {
@@ -469,28 +489,14 @@ html, body {
   overflow-x: hidden;
 }
 
-/* Ensure all containers respect the viewport width */
-.w-full {
-  width: 100% !important;
-  max-width: 100% !important;
-}
-
 /* Fix any potential grid overflow issues */
-.grid {
-  width: 100%;
+.main-content-area :where(.grid) {
   max-width: 100%;
 }
 
 /* Ensure form elements don't overflow */
 input, select, textarea {
   max-width: 100%;
-}
-
-/* Better responsive card layout */
-.card {
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
 }
 
 /* Improved mobile layout */


### PR DESCRIPTION
## Summary
- remove the global `.w-full` override so Tailwind responsive width utilities can apply
- scope overflow and width handling to the main content area, cards, and grids to keep layouts within the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce0ba9e650832fb195ff6fc8152752