### PR TITLE
Fix scroll helper ref typing

### DIFF
--- a/src/components/MonsterGenerator.tsx
+++ b/src/components/MonsterGenerator.tsx
@@ -181,7 +181,7 @@ export default function MonsterGenerator() {
   }, []);
 
   // Smooth scroll to section function
-  const scrollToSection = (ref: React.RefObject<HTMLDivElement>) => {
+  const scrollToSection = (ref: React.RefObject<HTMLDivElement | null>) => {
     ref.current?.scrollIntoView({
       behavior: 'smooth',
       block: 'start'


### PR DESCRIPTION
## Summary
- allow the scroll helper used by quick navigation buttons to accept refs that can be null, matching the component's useRef definitions and preventing build failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c85aed38832f9dd6395601374bdd