### PR TITLE
Display build metadata on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link';
 
+import { getBuildInfo } from '@/utils/buildInfo';
+
+const buildInfo = getBuildInfo();
+
 export default function Home() {
   return (
     <div className="container mx-auto px-4 py-8">
@@ -168,6 +172,18 @@ export default function Home() {
             <Link href="/documentation" className="text-blue-600 hover:text-blue-800">
               Documentation
             </Link>
+          </div>
+          <div className="mt-6 text-sm text-gray-500 space-y-1">
+            <p>
+              <span className="font-semibold">Build:</span>{' '}
+              <span title={`Full version: ${buildInfo.version}`}>
+                {buildInfo.displayVersion}
+              </span>
+            </p>
+            <p>
+              <span className="font-semibold">Updated:</span>{' '}
+              {buildInfo.formattedTimestamp ?? buildInfo.rawTimestamp ?? 'Unknown'}
+            </p>
           </div>
         </div>
       </footer>

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -1,0 +1,98 @@
+const versionEnvVarKeys = [
+  "NEXT_PUBLIC_APP_VERSION",
+  "NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA",
+  "VERCEL_GIT_COMMIT_SHA",
+  "NEXT_PUBLIC_GIT_COMMIT_SHA",
+  "GIT_COMMIT_SHA",
+  "COMMIT_REF",
+  "SOURCE_VERSION",
+];
+
+const timestampEnvVarKeys = [
+  "NEXT_PUBLIC_BUILD_TIMESTAMP",
+  "VERCEL_GIT_COMMIT_DATE",
+  "NEXT_PUBLIC_VERCEL_GIT_COMMIT_DATE",
+  "BUILD_TIMESTAMP",
+  "BUILD_TIME",
+  "SOURCE_VERSION_TIMESTAMP",
+];
+
+function readFirstEnvValue(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseTimestamp(rawValue: string | undefined): Date | undefined {
+  if (!rawValue) {
+    return undefined;
+  }
+
+  const numeric = Number(rawValue);
+  if (!Number.isNaN(numeric)) {
+    if (rawValue.length === 10) {
+      return new Date(numeric * 1000);
+    }
+    if (rawValue.length === 13) {
+      return new Date(numeric);
+    }
+    return new Date(numeric);
+  }
+
+  const parsed = new Date(rawValue);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function formatTimestamp(date: Date | undefined): string | undefined {
+  if (!date) {
+    return undefined;
+  }
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+
+  return formatter.format(date);
+}
+
+function createDisplayVersion(version: string): string {
+  const trimmed = version.trim();
+  if (trimmed.length <= 12) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 7)}…`;
+}
+
+export type BuildInfo = {
+  version: string;
+  displayVersion: string;
+  rawTimestamp?: string;
+  timestamp?: Date;
+  formattedTimestamp?: string;
+};
+
+export function getBuildInfo(): BuildInfo {
+  const version = readFirstEnvValue(versionEnvVarKeys) ?? "dev-local";
+  const rawTimestamp = readFirstEnvValue(timestampEnvVarKeys);
+  const timestamp = parseTimestamp(rawTimestamp);
+  const formattedTimestamp = formatTimestamp(timestamp);
+
+  return {
+    version,
+    displayVersion: createDisplayVersion(version),
+    rawTimestamp,
+    timestamp,
+    formattedTimestamp,
+  };
+}


### PR DESCRIPTION
## Summary
- surface build commit metadata on the home page footer so deployments expose their version
- add a shared utility that reads common environment variables and formats build timestamps for display

## Testing
- npm run lint *(fails: pre-existing lint errors in monster- and roster-related files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8275b2d30832f9692b81ec4916d62