### PR TITLE
Fix enhanced monster generator build issues

### DIFF
--- a/src/data/monsterData.ts
+++ b/src/data/monsterData.ts
@@ -215,7 +215,8 @@ export function validateThreatDiceForCategory(
   };
 
   const maxThreat = Math.max(...Object.values(threats));
-  const primaryThreatType = Object.entries(threats).find(([_, value]) => value === maxThreat)?.[0];
+  const primaryThreatEntry = Object.entries(threats).find(([, value]) => value === maxThreat);
+  const primaryThreatType = primaryThreatEntry?.[0];
 
   if (maxThreat === 0) {
     errors.push('At least one threat type must be specified');

--- a/src/utils/rosterUtils.ts
+++ b/src/utils/rosterUtils.ts
@@ -11,13 +11,31 @@ export interface RosterEntry {
   details: {
     source: string;
     summary?: string;
-    fullData?: any;
+    fullData?: unknown;
   };
 }
 
 export interface RosterFolder {
   name: string;
   pcs: string[];
+}
+
+interface GeneratorDetails {
+  summary?: string;
+}
+
+export interface NPCLike {
+  name?: string;
+  gender?: string;
+  summary?: string;
+  AD?: number | string;
+  PD?: number | string;
+  details?: GeneratorDetails;
+}
+
+export interface MonsterLike extends NPCLike {
+  category?: string;
+  nature?: string;
 }
 
 const FOLDERS_KEY = 'eldritch_roster_folders';
@@ -43,7 +61,7 @@ function findFolderIndexByName(folders: RosterFolder[], name: string): number {
   return folders.findIndex(folder => folder.name.toLowerCase() === name.toLowerCase());
 }
 
-export function saveNPCToRoster(npc: any, folderName: string = 'NPCs'): boolean {
+export function saveNPCToRoster<T extends NPCLike>(npc: T, folderName: string = 'NPCs'): boolean {
   try {
     const pcs = loadPCs();
     const folders = loadFolders();
@@ -90,7 +108,7 @@ export function saveNPCToRoster(npc: any, folderName: string = 'NPCs'): boolean 
   }
 }
 
-export function saveMonsterToRoster(monster: any, folderName: string = 'Monsters'): boolean {
+export function saveMonsterToRoster<T extends MonsterLike>(monster: T, folderName: string = 'Monsters'): boolean {
   try {
     const pcs = loadPCs();
     const folders = loadFolders();


### PR DESCRIPTION
## Summary
- add threat dice summary and enhanced QSB helpers to monster utilities and consume them from the enhanced generator
- tighten enhanced generator form types, movement breakdown display, and escape lint-sensitive strings
- update roster utilities to use typed inputs and quiet lint errors while keeping build passing

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86e7ae1d0832f8aa63fde73a3ed13