### PR TITLE
Create player and GM landing cards on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,146 +13,41 @@ export default function Home() {
       </header>
 
       <main>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">🎲 GM Tool Suite</h2>
-            <p className="text-gray-600 mb-4">
-              All-in-one toolkit with encounter generator, NPC creator, battle calculator, and more.
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow">
+            <h2 className="text-3xl font-extrabold text-gray-900 mb-4">For Players</h2>
+            <p className="text-lg text-gray-600 mb-6">
+              Jump straight into character creation, spell references, and tools to keep your hero ready for every eldritch encounter.
             </p>
+            <ul className="space-y-3 text-gray-600">
+              <li>• Quick character and NPC builders tailored for player use.</li>
+              <li>• Access to spellbooks, equipment, and lore summaries.</li>
+              <li>• Resources to track progress, parties, and campaign history.</li>
+            </ul>
+            <Link
+              href="/player-tools"
+              className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
+            >
+              Explore Player Tools
+            </Link>
+          </div>
+
+          <div className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow">
+            <h2 className="text-3xl font-extrabold text-gray-900 mb-4">For Game Masters</h2>
+            <p className="text-lg text-gray-600 mb-6">
+              Orchestrate unforgettable sessions with encounter planning, monster management, and campaign organization at your fingertips.
+            </p>
+            <ul className="space-y-3 text-gray-600">
+              <li>• Comprehensive encounter and monster generators.</li>
+              <li>• Battle calculators, rosters, and party management dashboards.</li>
+              <li>• Direct links to rules, documentation, and the full bestiary.</li>
+            </ul>
             <Link
               href="/gm-tools"
-              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
+              className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
             >
-              Launch GM Tools
+              Explore GM Tools
             </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">⚔️ Advanced Encounter Generator</h2>
-            <p className="text-gray-600 mb-4">
-              Create balanced encounters with detailed monster statistics and threat calculations.
-            </p>
-            <Link
-              href="/encounter-generator"
-              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-            >
-              Generate Encounters
-            </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">👤 Character Generator</h2>
-            <p className="text-gray-600 mb-4">
-              Generate complete player characters for Eldritch RPG 2nd Edition.
-            </p>
-            <Link
-              href="/character-generator"
-              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-            >
-              Create Characters
-            </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">🧙 NPC Generator</h2>
-            <p className="text-gray-600 mb-4">
-              Create detailed non-player characters with stats, backgrounds, and equipment.
-            </p>
-            <div className="space-y-2">
-              <Link
-                href="/npc-generator"
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors mr-2"
-              >
-                Generate NPCs
-              </Link>
-              <Link
-                href="/npc-roster"
-                className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-              >
-                NPC Roster
-              </Link>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">👹 Monster Generator</h2>
-            <p className="text-gray-600 mb-4">
-              Generate creatures and monsters for your Eldritch RPG encounters.
-            </p>
-            <div className="space-y-2">
-              <Link
-                href="/monster-generator"
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors mr-2"
-              >
-                Create Monsters
-              </Link>
-              <Link
-                href="/monster-roster"
-                className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-              >
-                Monster Roster
-              </Link>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">📖 Beings Diverse and Malign</h2>
-            <p className="text-gray-600 mb-4">
-              The complete bestiary of creatures, monsters, and adversaries from the Eldritch archives.
-            </p>
-            <Link
-              href="/bestiary"
-              className="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-            >
-              🎲 Access Bestiary
-            </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">⚡ Battle Phase Calculator</h2>
-            <p className="text-gray-600 mb-4">
-              Track initiative, manage combat rounds, and calculate battle phases.
-            </p>
-            <Link
-              href="/battle-calculator"
-              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-            >
-              Battle Calculator
-            </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">📚 Grimoire Index</h2>
-            <p className="text-gray-600 mb-4">
-              Browse spell and magic references for your Eldritch RPG campaigns.
-            </p>
-            <Link
-              href="/grimoire"
-              className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-            >
-              View Grimoire
-            </Link>
-          </div>
-
-          <div className="bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow">
-            <h2 className="text-2xl font-bold mb-3">🗂️ Party Management</h2>
-            <p className="text-gray-600 mb-4">
-              Organize characters into party folders, manage groups, and calculate party defense levels for encounter balancing.
-            </p>
-            <div className="space-y-2">
-              <Link
-                href="/party-management"
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors mr-2"
-              >
-                Party Manager
-              </Link>
-              <Link
-                href="/roster"
-                className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded inline-block transition-colors"
-              >
-                PC Roster
-              </Link>
-            </div>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- replace the homepage tool grid with two prominent panels
- highlight dedicated resources for players and GMs with descriptive copy
- wire the new calls-to-action to the player and GM tool hubs

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1f7663c0832facbc7e42d97dce0f