### PR TITLE
Add player tools landing page with shared feature card component

### DIFF
--- a/src/app/gm-tools/page.tsx
+++ b/src/app/gm-tools/page.tsx
@@ -1,93 +1,78 @@
 import Link from 'next/link';
+import { FeatureCard } from '@/components/FeatureCard';
+
+const gmFeatures = [
+  {
+    icon: '⚔️',
+    title: 'Encounter Generator',
+    description: 'Create balanced encounters with detailed statistics.',
+    links: [{ href: '/encounter-generator', label: 'Generate Encounters →' }],
+  },
+  {
+    icon: '👤',
+    title: 'Character Tools',
+    description: 'Generate and manage player characters.',
+    links: [
+      { href: '/character-generator', label: 'Character Generator →' },
+      { href: '/roster', label: 'Character Roster →' },
+    ],
+  },
+  {
+    icon: '🧙',
+    title: 'NPC Tools',
+    description: 'Create and organize non-player characters.',
+    links: [
+      { href: '/npc-generator', label: 'NPC Generator →' },
+      { href: '/npc-roster', label: 'NPC Roster →' },
+    ],
+  },
+  {
+    icon: '👹',
+    title: 'Monster Tools',
+    description: 'Generate creatures and manage bestiary.',
+    links: [
+      { href: '/monster-generator', label: 'Monster Generator →' },
+      { href: '/monster-roster', label: 'Monster Roster →' },
+    ],
+  },
+  {
+    icon: '⚡',
+    title: 'Battle Calculator',
+    description: 'Track combat and manage battle phases.',
+    links: [{ href: '/battle-calculator', label: 'Battle Calculator →' }],
+  },
+  {
+    icon: '📝',
+    title: 'Game Content Parser',
+    description:
+      'Analyze and validate stat blocks, spells, and magic items for compliance.',
+    links: [{ href: '/stat-block-parser', label: 'Parse Game Content →' }],
+  },
+  {
+    icon: '📚',
+    title: 'References',
+    description: 'Quick access to rules and spell references.',
+    links: [
+      { href: '/grimoire', label: 'Grimoire →' },
+      { href: '/rules', label: 'Rules Reference →' },
+    ],
+  },
+];
 
 export default function GMTools() {
   return (
     <div className="container mx-auto px-4 py-8">
       <header className="text-center mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">
-          GM Tool Suite
-        </h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">GM Tool Suite</h1>
         <p className="text-lg text-gray-600">
           All-in-one toolkit for Game Masters running Eldritch RPG campaigns
         </p>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">⚔️ Encounter Generator</h3>
-          <p className="text-gray-600 mb-4">Create balanced encounters with detailed statistics.</p>
-          <Link href="/encounter-generator" className="text-blue-600 hover:text-blue-800 font-medium">
-            Generate Encounters →
-          </Link>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">👤 Character Tools</h3>
-          <p className="text-gray-600 mb-4">Generate and manage player characters.</p>
-          <div className="space-y-2">
-            <Link href="/character-generator" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Character Generator →
-            </Link>
-            <Link href="/roster" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Character Roster →
-            </Link>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">🧙 NPC Tools</h3>
-          <p className="text-gray-600 mb-4">Create and organize non-player characters.</p>
-          <div className="space-y-2">
-            <Link href="/npc-generator" className="block text-blue-600 hover:text-blue-800 font-medium">
-              NPC Generator →
-            </Link>
-            <Link href="/npc-roster" className="block text-blue-600 hover:text-blue-800 font-medium">
-              NPC Roster →
-            </Link>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">👹 Monster Tools</h3>
-          <p className="text-gray-600 mb-4">Generate creatures and manage bestiary.</p>
-          <div className="space-y-2">
-            <Link href="/monster-generator" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Monster Generator →
-            </Link>
-            <Link href="/monster-roster" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Monster Roster →
-            </Link>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">⚡ Battle Calculator</h3>
-          <p className="text-gray-600 mb-4">Track combat and manage battle phases.</p>
-          <Link href="/battle-calculator" className="text-blue-600 hover:text-blue-800 font-medium">
-            Battle Calculator →
-          </Link>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">📝 Game Content Parser</h3>
-          <p className="text-gray-600 mb-4">Analyze and validate stat blocks, spells, and magic items for compliance.</p>
-          <Link href="/stat-block-parser" className="text-blue-600 hover:text-blue-800 font-medium">
-            Parse Game Content →
-          </Link>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h3 className="text-xl font-bold mb-3">📚 References</h3>
-          <p className="text-gray-600 mb-4">Quick access to rules and spell references.</p>
-          <div className="space-y-2">
-            <Link href="/grimoire" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Grimoire →
-            </Link>
-            <Link href="/rules" className="block text-blue-600 hover:text-blue-800 font-medium">
-              Rules Reference →
-            </Link>
-          </div>
-        </div>
+        {gmFeatures.map((feature) => (
+          <FeatureCard key={feature.title} {...feature} />
+        ))}
       </div>
 
       <div className="text-center">

--- a/src/app/player-tools/page.tsx
+++ b/src/app/player-tools/page.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+import { FeatureCard } from '@/components/FeatureCard';
+
+const playerFeatures = [
+  {
+    icon: '🛠️',
+    title: 'Character Creation',
+    description: 'Build new heroes and keep their sheets updated in one place.',
+    links: [
+      { href: '/character-generator', label: 'Character Generator →' },
+      { href: '/roster', label: 'Character Roster →' },
+    ],
+  },
+  {
+    icon: '🤝',
+    title: 'Party Dashboard',
+    description: 'Coordinate tactics, track resources, and share discoveries with your team.',
+    links: [{ href: '/party-management', label: 'Open Party Management →' }],
+  },
+  {
+    icon: '📖',
+    title: 'Spell & Ritual Library',
+    description: 'Browse every spell, ritual, and magical effect your character can learn.',
+    links: [{ href: '/grimoire', label: 'Explore the Grimoire →' }],
+  },
+  {
+    icon: '⚖️',
+    title: 'Rules Reference',
+    description: 'Quick rulings, condition summaries, and core mechanics at your fingertips.',
+    links: [{ href: '/rules', label: 'Consult the Rules →' }],
+  },
+  {
+    icon: '🐾',
+    title: 'Field Guide',
+    description: 'Study known creatures, weaknesses, and lore before the next expedition.',
+    links: [{ href: '/bestiary', label: 'Review the Bestiary →' }],
+  },
+  {
+    icon: '🧭',
+    title: 'Player Documentation',
+    description: 'Access campaign notes, house rules, and onboarding guides.',
+    links: [{ href: '/documentation', label: 'Read the Documentation →' }],
+  },
+];
+
+export default function PlayerTools() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="text-center mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Player Tool Suite</h1>
+        <p className="text-lg text-gray-600">
+          Essential resources to prepare, play, and excel in Eldritch RPG adventures
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        {playerFeatures.map((feature) => (
+          <FeatureCard key={feature.title} {...feature} />
+        ))}
+      </div>
+
+      <div className="text-center">
+        <Link
+          href="/"
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition-colors"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+type FeatureLink = {
+  href: string;
+  label: string;
+};
+
+type FeatureCardProps = {
+  title: string;
+  description: string;
+  links: FeatureLink[];
+  icon?: string;
+};
+
+export function FeatureCard({ title, description, links, icon }: FeatureCardProps) {
+  const [primaryLink, ...additionalLinks] = links;
+  const hasMultipleLinks = additionalLinks.length > 0;
+  const linkItems = primaryLink ? [primaryLink, ...additionalLinks] : additionalLinks;
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <h3 className="text-xl font-bold mb-3">
+        {icon ? <span className="mr-1" aria-hidden="true">{icon}</span> : null}
+        {title}
+      </h3>
+      <p className="text-gray-600 mb-4">{description}</p>
+      {hasMultipleLinks ? (
+        <div className="space-y-2">
+          {linkItems.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="block text-blue-600 hover:text-blue-800 font-medium"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      ) : primaryLink ? (
+        <Link
+          href={primaryLink.href}
+          className="text-blue-600 hover:text-blue-800 font-medium"
+        >
+          {primaryLink.label}
+        </Link>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable FeatureCard component to display tool links
- refactor the GM tools index to consume the shared card component
- create a player tools landing page mirroring the GM layout with player-focused links

## Testing
- npm run lint *(fails: npm command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f7bbab8832fbe7b38bcd7fb8e92