### PR TITLE
Add campaign backup utilities and UI controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,101 @@
+'use client';
+
+import { useCallback, useRef, useState, type ChangeEvent } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { exportCampaign, importCampaign } from '@/utils/campaignBackup';
+
 export default function Home() {
+  const [, setRefreshCounter] = useState(0);
+  const [feedback, setFeedback] = useState<{
+    type: 'success' | 'error';
+    message: string;
+  } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSaveCampaign = useCallback(() => {
+    try {
+      const backup = exportCampaign();
+      const blob = new Blob([JSON.stringify(backup, null, 2)], {
+        type: 'application/json'
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `eldritch-campaign-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      setFeedback({ type: 'success', message: 'Campaign backup saved to your device.' });
+    } catch (error) {
+      console.error('Error exporting campaign backup:', error);
+      setFeedback({ type: 'error', message: 'Unable to save campaign backup.' });
+    }
+  }, []);
+
+  const clearFileInput = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
+  const handleLoadCampaign = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.json')) {
+      setFeedback({ type: 'error', message: 'Please select a JSON backup file.' });
+      clearFileInput();
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const text = reader.result;
+        if (typeof text !== 'string') {
+          throw new Error('Unable to read file contents.');
+        }
+        const parsed = JSON.parse(text);
+        const result = importCampaign(parsed);
+
+        if (!result.success) {
+          setFeedback({
+            type: 'error',
+            message: result.error || 'Failed to import campaign backup.'
+          });
+        } else {
+          setFeedback({
+            type: 'success',
+            message: 'Campaign backup imported successfully.'
+          });
+          setRefreshCounter(counter => counter + 1);
+        }
+      } catch (error) {
+        console.error('Error processing campaign backup:', error);
+        setFeedback({
+          type: 'error',
+          message: 'The selected file is not a valid campaign backup.'
+        });
+      } finally {
+        clearFileInput();
+      }
+    };
+
+    reader.onerror = () => {
+      console.error('Error reading campaign backup file:', reader.error);
+      setFeedback({ type: 'error', message: 'Unable to read the selected file.' });
+      clearFileInput();
+    };
+
+    reader.readAsText(file);
+  }, [clearFileInput]);
+
   return (
     <div className="container mx-auto px-4 py-8">
       <header className="mb-12">
@@ -27,6 +121,44 @@ export default function Home() {
       </header>
 
       <main>
+        <section className="mb-12 rounded-2xl border border-blue-200 bg-blue-50 p-8 shadow-sm">
+          <h2 className="text-2xl font-bold text-blue-900">Campaign Backups</h2>
+          <p className="mt-2 text-sm text-blue-800">
+            Save a local JSON file with all PCs, NPCs, monsters, party folders, roster folders, and encounter templates, or
+            restore a backup to sync your tools.
+          </p>
+          <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={handleSaveCampaign}
+              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Save Campaign
+            </button>
+            <label className="inline-flex cursor-pointer flex-col items-start gap-2 text-sm font-medium text-blue-900 sm:flex-row sm:items-center">
+              <span className="rounded-md border border-dashed border-blue-400 bg-white px-5 py-3 text-center text-sm font-semibold text-blue-700 shadow-sm transition-colors hover:border-blue-500 hover:text-blue-800">
+                Load Campaign Backup
+              </span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                onChange={handleLoadCampaign}
+                className="hidden"
+              />
+            </label>
+          </div>
+          {feedback && (
+            <p
+              className={`mt-4 text-sm font-semibold ${
+                feedback.type === 'success' ? 'text-green-700' : 'text-red-700'
+              }`}
+            >
+              {feedback.message}
+            </p>
+          )}
+        </section>
+
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
           <div className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow">
             <h2 className="text-3xl font-extrabold text-gray-900 mb-4">For Players</h2>

--- a/src/utils/campaignBackup.ts
+++ b/src/utils/campaignBackup.ts
@@ -1,0 +1,156 @@
+import {
+  EncounterTemplate,
+  PartyFolder,
+  PartyMembership,
+  SavedCharacter
+} from '@/types/party';
+import {
+  getAllCharacters,
+  getAllEncounterTemplates,
+  getAllPartyFolders,
+  getAllPartyMemberships,
+  STORAGE_KEYS
+} from '@/utils/partyStorage';
+import {
+  ROSTER_STORAGE_KEYS,
+  RosterEntry,
+  RosterFolder,
+  getAllRosterEntries,
+  getAllRosterFolders
+} from '@/utils/rosterUtils';
+
+export interface CampaignBackupData {
+  characters: SavedCharacter[];
+  partyFolders: PartyFolder[];
+  partyMemberships: PartyMembership[];
+  encounterTemplates: EncounterTemplate[];
+  rosterFolders: RosterFolder[];
+  rosterEntries: Record<string, RosterEntry>;
+  exportedAt: string;
+  version: number;
+}
+
+export interface CampaignImportResult {
+  success: boolean;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isCampaignBackup(payload: unknown): payload is CampaignBackupData {
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  const {
+    characters,
+    partyFolders,
+    partyMemberships,
+    encounterTemplates,
+    rosterFolders,
+    rosterEntries
+  } = payload as Record<string, unknown>;
+
+  const arraysAreValid =
+    Array.isArray(characters) &&
+    Array.isArray(partyFolders) &&
+    Array.isArray(partyMemberships) &&
+    Array.isArray(encounterTemplates) &&
+    Array.isArray(rosterFolders);
+
+  const rosterEntriesValid = isRecord(rosterEntries || {});
+
+  return arraysAreValid && rosterEntriesValid;
+}
+
+export function exportCampaign(): CampaignBackupData {
+  return {
+    characters: getAllCharacters(),
+    partyFolders: getAllPartyFolders(),
+    partyMemberships: getAllPartyMemberships(),
+    encounterTemplates: getAllEncounterTemplates(),
+    rosterFolders: getAllRosterFolders(),
+    rosterEntries: getAllRosterEntries(),
+    exportedAt: new Date().toISOString(),
+    version: 1
+  };
+}
+
+export function importCampaign(payload: unknown): CampaignImportResult {
+  try {
+    if (!isCampaignBackup(payload)) {
+      return { success: false, error: 'Invalid campaign backup format.' };
+    }
+
+    const campaign: CampaignBackupData = {
+      ...payload,
+      exportedAt:
+        typeof (payload as CampaignBackupData).exportedAt === 'string'
+          ? (payload as CampaignBackupData).exportedAt
+          : new Date().toISOString(),
+      version:
+        typeof (payload as CampaignBackupData).version === 'number'
+          ? (payload as CampaignBackupData).version
+          : 1
+    };
+
+    const serialized = {
+      characters: JSON.stringify(campaign.characters),
+      partyFolders: JSON.stringify(campaign.partyFolders),
+      partyMemberships: JSON.stringify(campaign.partyMemberships),
+      encounterTemplates: JSON.stringify(campaign.encounterTemplates),
+      rosterFolders: JSON.stringify(campaign.rosterFolders),
+      rosterEntries: JSON.stringify(campaign.rosterEntries)
+    };
+
+    const keys = [
+      STORAGE_KEYS.CHARACTERS,
+      STORAGE_KEYS.PARTY_FOLDERS,
+      STORAGE_KEYS.PARTY_MEMBERSHIPS,
+      STORAGE_KEYS.ENCOUNTER_TEMPLATES,
+      ROSTER_STORAGE_KEYS.FOLDERS,
+      ROSTER_STORAGE_KEYS.PCS
+    ];
+
+    const previousValues = new Map<string, string | null>();
+    keys.forEach(key => {
+      previousValues.set(key, localStorage.getItem(key));
+    });
+
+    try {
+      keys.forEach(key => {
+        localStorage.removeItem(key);
+      });
+
+      localStorage.setItem(STORAGE_KEYS.CHARACTERS, serialized.characters);
+      localStorage.setItem(STORAGE_KEYS.PARTY_FOLDERS, serialized.partyFolders);
+      localStorage.setItem(STORAGE_KEYS.PARTY_MEMBERSHIPS, serialized.partyMemberships);
+      localStorage.setItem(STORAGE_KEYS.ENCOUNTER_TEMPLATES, serialized.encounterTemplates);
+      localStorage.setItem(ROSTER_STORAGE_KEYS.FOLDERS, serialized.rosterFolders);
+      localStorage.setItem(ROSTER_STORAGE_KEYS.PCS, serialized.rosterEntries);
+    } catch (error) {
+      previousValues.forEach((value, key) => {
+        if (value === null) {
+          localStorage.removeItem(key);
+        } else {
+          localStorage.setItem(key, value);
+        }
+      });
+      throw error;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('eldritch-campaign-imported'));
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error('Error importing campaign backup:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error importing campaign.'
+    };
+  }
+}

--- a/src/utils/partyStorage.ts
+++ b/src/utils/partyStorage.ts
@@ -12,7 +12,7 @@ import {
 } from '../types/party';
 
 // Storage keys
-const STORAGE_KEYS = {
+export const STORAGE_KEYS = {
   CHARACTERS: 'eldritch_characters',
   PARTY_FOLDERS: 'eldritch_party_folders',
   PARTY_MEMBERSHIPS: 'eldritch_party_memberships',

--- a/src/utils/rosterUtils.ts
+++ b/src/utils/rosterUtils.ts
@@ -41,6 +41,11 @@ export interface MonsterLike extends NPCLike {
 const FOLDERS_KEY = 'eldritch_roster_folders';
 const PCS_KEY = 'eldritch_roster_pcs';
 
+export const ROSTER_STORAGE_KEYS = {
+  FOLDERS: FOLDERS_KEY,
+  PCS: PCS_KEY
+} as const;
+
 function loadFolders(): RosterFolder[] {
   return JSON.parse(localStorage.getItem(FOLDERS_KEY) || '[]');
 }
@@ -55,6 +60,24 @@ function loadPCs(): Record<string, RosterEntry> {
 
 function savePCs(pcs: Record<string, RosterEntry>): void {
   localStorage.setItem(PCS_KEY, JSON.stringify(pcs));
+}
+
+export function getAllRosterFolders(): RosterFolder[] {
+  try {
+    return loadFolders();
+  } catch (error) {
+    console.error('Error loading roster folders:', error);
+    return [];
+  }
+}
+
+export function getAllRosterEntries(): Record<string, RosterEntry> {
+  try {
+    return loadPCs();
+  } catch (error) {
+    console.error('Error loading roster entries:', error);
+    return {};
+  }
 }
 
 function findFolderIndexByName(folders: RosterFolder[], name: string): number {


### PR DESCRIPTION
## Summary
- convert the home page to a client component and surface save/load controls for campaign backups
- add campaignBackup utilities to export and import characters, parties, encounters, and roster data safely
- expose roster storage helpers and storage key constants for coordinated backup restores

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc28f20d04832f85498ba5530028fd