### PR TITLE
Add player tools entry points across the suite

### DIFF
--- a/src/app/gm-tools/page.tsx
+++ b/src/app/gm-tools/page.tsx
@@ -90,12 +90,18 @@ export default function GMTools() {
         </div>
       </div>
 
-      <div className="text-center">
+      <div className="mt-12 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
         <Link
           href="/"
           className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition-colors"
         >
           Back to Home
+        </Link>
+        <Link
+          href="/player-tools"
+          className="bg-white border border-blue-200 text-blue-700 hover:text-blue-900 hover:border-blue-300 font-bold py-2 px-4 rounded transition-colors shadow-sm"
+        >
+          Explore Player Tools
         </Link>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,6 +96,37 @@ export default function Home() {
     reader.readAsText(file);
   }, [clearFileInput]);
 
+  const heroCards = [
+    {
+      title: 'Player Tools',
+      description:
+        'Jump straight into character creation, spell references, and tools to keep your hero ready for every eldritch encounter.',
+      bullets: [
+        'Quick-start character, party, and NPC builders tailored for players.',
+        'Spellbooks, equipment references, and lore summaries at the table.',
+        'Track progress, quests, and campaign history with shared resources.'
+      ],
+      cta: {
+        href: '/player-tools',
+        label: 'Explore Player Tools'
+      }
+    },
+    {
+      title: 'GM Tools',
+      description:
+        'Orchestrate unforgettable sessions with encounter planning, monster management, and campaign organization at your fingertips.',
+      bullets: [
+        'Comprehensive encounter and monster generators.',
+        'Battle calculators, rosters, and party management dashboards.',
+        'Direct links to rules, documentation, and the full bestiary.'
+      ],
+      cta: {
+        href: '/gm-tools',
+        label: 'Explore GM Tools'
+      }
+    }
+  ];
+
   return (
     <div className="container mx-auto px-4 py-8">
       <header className="mb-12">
@@ -160,41 +191,26 @@ export default function Home() {
         </section>
 
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-          <div className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow">
-            <h2 className="text-3xl font-extrabold text-gray-900 mb-4">For Players</h2>
-            <p className="text-lg text-gray-600 mb-6">
-              Jump straight into character creation, spell references, and tools to keep your hero ready for every eldritch encounter.
-            </p>
-            <ul className="space-y-3 text-gray-600">
-              <li>• Quick character and NPC builders tailored for player use.</li>
-              <li>• Access to spellbooks, equipment, and lore summaries.</li>
-              <li>• Resources to track progress, parties, and campaign history.</li>
-            </ul>
-            <Link
-              href="/player-tools"
-              className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
+          {heroCards.map(card => (
+            <div
+              key={card.title}
+              className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow"
             >
-              Explore Player Tools
-            </Link>
-          </div>
-
-          <div className="flex flex-col bg-white rounded-2xl shadow-lg p-8 hover:shadow-xl transition-shadow">
-            <h2 className="text-3xl font-extrabold text-gray-900 mb-4">For Game Masters</h2>
-            <p className="text-lg text-gray-600 mb-6">
-              Orchestrate unforgettable sessions with encounter planning, monster management, and campaign organization at your fingertips.
-            </p>
-            <ul className="space-y-3 text-gray-600">
-              <li>• Comprehensive encounter and monster generators.</li>
-              <li>• Battle calculators, rosters, and party management dashboards.</li>
-              <li>• Direct links to rules, documentation, and the full bestiary.</li>
-            </ul>
-            <Link
-              href="/gm-tools"
-              className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
-            >
-              Explore GM Tools
-            </Link>
-          </div>
+              <h2 className="text-3xl font-extrabold text-gray-900 mb-4">{card.title}</h2>
+              <p className="text-lg text-gray-600 mb-6">{card.description}</p>
+              <ul className="space-y-3 text-gray-600">
+                {card.bullets.map(bullet => (
+                  <li key={bullet}>• {bullet}</li>
+                ))}
+              </ul>
+              <Link
+                href={card.cta.href}
+                className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
+              >
+                {card.cta.label}
+              </Link>
+            </div>
+          ))}
         </div>
       </main>
 

--- a/src/app/player-tools/page.tsx
+++ b/src/app/player-tools/page.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+
+const playerResources = [
+  {
+    title: 'Character Toolkit',
+    description:
+      'Build and maintain your Eldritch heroes with streamlined creation tools and shared rosters for your party.',
+    links: [
+      { href: '/character-generator', label: 'Character Generator →' },
+      { href: '/roster', label: 'Character Roster →' }
+    ]
+  },
+  {
+    title: 'Spell & Lore Reference',
+    description:
+      'Keep your spellbooks, equipment options, and rules clarifications close at hand during every session.',
+    links: [
+      { href: '/grimoire', label: 'Grimoire →' },
+      { href: '/rules', label: 'Rules Reference →' }
+    ]
+  },
+  {
+    title: 'Campaign Resources',
+    description:
+      'Coordinate with your group through shared documentation and manage party folders as your story unfolds.',
+    links: [
+      { href: '/party-management', label: 'Party Management →' },
+      { href: '/documentation', label: 'Documentation →' }
+    ]
+  }
+];
+
+export default function PlayerToolsPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="text-center mb-10">
+        <h1 className="text-3xl font-bold text-gray-900 mb-3">Player Tools</h1>
+        <p className="text-lg text-gray-600">
+          Stay prepared for every Eldritch RPG adventure with quick access to character utilities, spell references, and
+          campaign coordination aids.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 mb-12">
+        {playerResources.map(section => (
+          <div key={section.title} className="bg-white rounded-lg shadow-lg p-6">
+            <h2 className="text-xl font-bold text-gray-900 mb-3">{section.title}</h2>
+            <p className="text-gray-600 mb-4">{section.description}</p>
+            <div className="space-y-2">
+              {section.links.map(link => (
+                <Link key={link.href} href={link.href} className="block text-blue-600 hover:text-blue-800 font-medium">
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <Link
+          href="/"
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition-colors"
+        >
+          Back to Home
+        </Link>
+        <Link
+          href="/gm-tools"
+          className="bg-white border border-blue-200 text-blue-700 hover:text-blue-900 hover:border-blue-300 font-bold py-2 px-4 rounded transition-colors shadow-sm"
+        >
+          Explore GM Tools
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Player Tools CTA to the homepage hero grid using the existing card styling
- add a secondary Player Tools button to the GM Tools page for quick cross-navigation
- create a Player Tools landing page that highlights core resources for players

## Testing
- curl -I http://localhost:3000/player-tools

------
https://chatgpt.com/codex/tasks/task_e_68dc39c0c298832fa821a8970c925d83