### PR TITLE
Fix search params typing and suspense requirements

### DIFF
--- a/src/app/battle-calculator/page.tsx
+++ b/src/app/battle-calculator/page.tsx
@@ -1,13 +1,13 @@
 import BattleCalculator from '../../components/BattleCalculator';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function BattleCalculatorPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function BattleCalculatorPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/bestiary/page.tsx
+++ b/src/app/bestiary/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import Bestiary from '../../components/Bestiary';
 
 export default function BestiaryPage() {
-  return <Bestiary />;
+  return (
+    <Suspense fallback={<div className="p-4 text-center">Loading bestiary...</div>}>
+      <Bestiary />
+    </Suspense>
+  );
 }

--- a/src/app/character-generator/page.tsx
+++ b/src/app/character-generator/page.tsx
@@ -1,13 +1,13 @@
 import CharacterGenerator from '../../components/CharacterGenerator';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function CharacterGeneratorPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'player-tools');
+export default async function CharacterGeneratorPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'player-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/documentation/page.tsx
+++ b/src/app/documentation/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function Documentation({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function Documentation({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/app/encounter-generator/page.tsx
+++ b/src/app/encounter-generator/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { Suspense, useCallback, useMemo, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -165,6 +165,14 @@ function generateMonster(
 }
 
 export default function EncounterGeneratorPage() {
+  return (
+    <Suspense fallback={<div className="p-4 text-center">Loading encounter generator...</div>}>
+      <EncounterGeneratorContent />
+    </Suspense>
+  );
+}
+
+function EncounterGeneratorContent() {
   const searchParams = useSearchParams();
   const backTarget = resolveBackTargetFromParam(searchParams.get('from'), 'gm-tools');
 

--- a/src/app/grimoire/page.tsx
+++ b/src/app/grimoire/page.tsx
@@ -1,13 +1,13 @@
 import GrimoireIndex from '../../components/GrimoireIndex';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function GrimoirePage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'player-tools');
+export default async function GrimoirePage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'player-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/monster-generator/page.tsx
+++ b/src/app/monster-generator/page.tsx
@@ -1,13 +1,13 @@
 import EnhancedMonsterGenerator from '../../components/EnhancedMonsterGenerator';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function MonsterGeneratorPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function MonsterGeneratorPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/monster-roster/page.tsx
+++ b/src/app/monster-roster/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function MonsterRoster({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function MonsterRoster({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/app/npc-generator/page.tsx
+++ b/src/app/npc-generator/page.tsx
@@ -1,13 +1,13 @@
 import AdvancedNPCGenerator from '../../components/AdvancedNPCGenerator';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function NPCGeneratorPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function NPCGeneratorPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/npc-roster/page.tsx
+++ b/src/app/npc-roster/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function NPCRoster({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function NPCRoster({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/app/party-management/page.tsx
+++ b/src/app/party-management/page.tsx
@@ -1,13 +1,13 @@
 import PartyManagement from '../../components/PartyManagement';
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function PartyManagementPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'player-tools');
+export default async function PartyManagementPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'player-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/app/roster/page.tsx
+++ b/src/app/roster/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import {
@@ -19,7 +19,7 @@ import {
 import { SavedCharacter, PartyFolder, PartyMembership } from '../../types/party';
 import { resolveBackTargetFromParam } from '../../utils/backNavigation';
 
-export default function Roster() {
+function RosterContent() {
   const searchParams = useSearchParams();
   const backTarget = resolveBackTargetFromParam(searchParams.get('from'), 'player-tools');
 
@@ -358,5 +358,13 @@ export default function Roster() {
         </Link>
       </div>
     </div>
+  );
+}
+
+export default function Roster() {
+  return (
+    <Suspense fallback={<div className="p-4 text-center">Loading roster...</div>}>
+      <RosterContent />
+    </Suspense>
   );
 }

--- a/src/app/rules/page.tsx
+++ b/src/app/rules/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
+import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
-};
+type PageProps = PagePropsWithSearchParams;
 
-export default function Rules({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'player-tools');
+export default async function Rules({ searchParams }: PageProps) {
+  const resolvedSearchParams = await resolvePageSearchParams(searchParams);
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'player-tools');
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,0 +1,9 @@
+export type PageSearchParams = Record<string, string | string[] | undefined>;
+
+export type PagePropsWithSearchParams = {
+  searchParams?: Promise<PageSearchParams>;
+};
+
+export const resolvePageSearchParams = async (
+  searchParams?: PagePropsWithSearchParams['searchParams']
+) => (searchParams ? await searchParams : undefined);


### PR DESCRIPTION
## Summary
- add a shared helper for resolving Next.js searchParams promises
- update app pages that accept searchParams to await the resolved values
- wrap pages that rely on useSearchParams in Suspense boundaries to satisfy Next.js 15 requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5f5a69dc832fa02f2dd443636493