### PR TITLE
Fix battle calculator page search param typing for Next.js 15

### DIFF
--- a/src/app/battle-calculator/page.tsx
+++ b/src/app/battle-calculator/page.tsx
@@ -3,11 +3,12 @@ import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
 
 type PageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default function BattleCalculatorPage({ searchParams }: PageProps) {
-  const backTarget = resolveBackTargetFromSearchParams(searchParams, 'gm-tools');
+export default async function BattleCalculatorPage({ searchParams }: PageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 
   return (
     <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
## Summary
- update the battle calculator page to await the Next.js 15 asynchronous `searchParams`
- resolve back navigation using the resolved search parameters to satisfy the new typing requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dda7ed80ec832fb98768601c521040