### PR TITLE
Fix battle calculator page module syntax error

### DIFF
--- a/src/app/battle-calculator/page.tsx
+++ b/src/app/battle-calculator/page.tsx
@@ -3,18 +3,10 @@ import Link from 'next/link';
 import { resolveBackTargetFromSearchParams } from '../../utils/backNavigation';
 import { PagePropsWithSearchParams, resolvePageSearchParams } from '../../types/page';
 
-
 type PageProps = PagePropsWithSearchParams;
 
 export default async function BattleCalculatorPage({ searchParams }: PageProps) {
   const resolvedSearchParams = await resolvePageSearchParams(searchParams);
-
-type PageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-export default async function BattleCalculatorPage({ searchParams }: PageProps) {
-  const resolvedSearchParams = searchParams ? await searchParams : undefined;
 
   const backTarget = resolveBackTargetFromSearchParams(resolvedSearchParams, 'gm-tools');
 


### PR DESCRIPTION
## Summary
- remove duplicate type and export declarations from the battle calculator page to restore valid module syntax
- reuse the shared search parameter resolver helper for consistent handling of optional searchParams

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddb748909c832fb030e85137e689c9