### PR TITLE
Highlight bestiary access from GM tools

### DIFF
--- a/src/app/gm-tools/page.tsx
+++ b/src/app/gm-tools/page.tsx
@@ -12,6 +12,32 @@ export default function GMTools() {
         </p>
       </header>
 
+      <section className="mb-10 rounded-2xl border border-purple-200 bg-purple-50 p-6 shadow-sm">
+        <div className="flex flex-col gap-4 text-center md:flex-row md:items-center md:justify-between md:text-left">
+          <div>
+            <h2 className="text-2xl font-bold text-purple-900 mb-2">📖 Explore the Full Bestiary</h2>
+            <p className="text-purple-800">
+              Dive into the complete catalog of eldritch creatures, filter by threat level, and pull stat blocks straight into
+              your encounters.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/bestiary?from=gm-tools"
+              className="inline-flex items-center justify-center rounded-md bg-purple-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-purple-700 transition-colors"
+            >
+              Open Bestiary Catalog →
+            </Link>
+            <Link
+              href="/monster-roster?from=gm-tools"
+              className="inline-flex items-center justify-center rounded-md border border-purple-200 bg-white px-5 py-3 text-sm font-semibold text-purple-800 shadow-sm hover:border-purple-300 hover:text-purple-900 transition-colors"
+            >
+              Manage Custom Monsters
+            </Link>
+          </div>
+        </div>
+      </section>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         <div className="bg-white rounded-lg shadow-lg p-6">
           <h3 className="text-xl font-bold mb-3">⚔️ Encounter Generator</h3>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,7 +96,15 @@ export default function Home() {
     reader.readAsText(file);
   }, [clearFileInput]);
 
-  const heroCards = [
+  interface HeroCard {
+    title: string;
+    description: string;
+    bullets: string[];
+    cta: { href: string; label: string };
+    secondaryCtas?: { href: string; label: string }[];
+  }
+
+  const heroCards: HeroCard[] = [
     {
       title: 'Player Tools',
       description:
@@ -123,7 +131,13 @@ export default function Home() {
       cta: {
         href: '/gm-tools',
         label: 'Explore GM Tools'
-      }
+      },
+      secondaryCtas: [
+        {
+          href: '/bestiary?from=home',
+          label: 'Browse Bestiary Catalog'
+        }
+      ]
     }
   ];
 
@@ -203,12 +217,23 @@ export default function Home() {
                   <li key={bullet}>• {bullet}</li>
                 ))}
               </ul>
-              <Link
-                href={card.cta.href}
-                className="mt-8 inline-block self-start bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded transition-colors"
-              >
-                {card.cta.label}
-              </Link>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={card.cta.href}
+                  className="inline-flex items-center justify-center rounded-md bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 transition-colors"
+                >
+                  {card.cta.label}
+                </Link>
+                {card.secondaryCtas?.map(secondary => (
+                  <Link
+                    key={secondary.href}
+                    href={secondary.href}
+                    className="inline-flex items-center justify-center rounded-md border border-blue-200 bg-white px-5 py-3 text-sm font-semibold text-blue-700 shadow-sm transition-colors hover:border-blue-300 hover:text-blue-900"
+                  >
+                    {secondary.label}
+                  </Link>
+                ))}
+              </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated bestiary callout to the GM Tools hub for quick catalog access
- surface a home page call-to-action that links straight to the bestiary catalog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddbdbc8778832fba006a7119a06b82