### PR TITLE
Replace bestiary warning icon with dragon emoji

### DIFF
--- a/src/components/Bestiary.tsx
+++ b/src/components/Bestiary.tsx
@@ -1011,7 +1011,7 @@ export default function Bestiary() {
           The Eldritch RPG Bestiary - A comprehensive guide to creatures, monsters, and adversaries
         </p>
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-800">
-          <p className="font-semibold">⚠️ Warning: Dangerous Knowledge</p>
+          <p className="font-semibold">🐉 Warning: Dangerous Knowledge</p>
           <p>This information is considered not safe to know and is normally kept locked and chained in the archives of the Octocirculi Academy.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the bestiary warning banner to use a dragon emoji instead of the warning symbol

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dddd7b1184832f9f7ab9493cfc6fb9