### PR TITLE
Add manual character builder and shared build helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A modernized web application for running Eldritch RPG campaigns. The suite provi
 
 > The original HTML utilities and reference spreadsheets are still shipped alongside the app inside the repository. They can be opened directly if you prefer the legacy experience.
 
+## 🧙 Player Character Workflows
+
+- **Character Generator** – `/character-generator` rapidly produces leveled heroes by spending CP according to selected build philosophies. Ideal when you want a balanced, hybrid, or specialist archetype in a few clicks.
+- **Manual Character Builder** – `/character-builder` walks you through race/class/level selection and exposes plus/minus controls for every ability, specialty, and focus. It tracks CP budgets by level, enforces racial/class minima, reuses the generator math for validation, and lets you fine-tune characters before saving them to the roster.
+
 ## 🚀 Getting Started
 
 ### Prerequisites

--- a/src/app/character-builder/page.tsx
+++ b/src/app/character-builder/page.tsx
@@ -1,0 +1,5 @@
+import ManualCharacterBuilder from '../../components/ManualCharacterBuilder';
+
+export default function CharacterBuilderPage() {
+  return <ManualCharacterBuilder />;
+}

--- a/src/app/player-tools/page.tsx
+++ b/src/app/player-tools/page.tsx
@@ -7,6 +7,7 @@ const playerResources = [
       'Build and maintain your Eldritch heroes with streamlined creation tools and shared rosters for your party.',
     links: [
       { href: '/character-generator?from=player-tools', label: 'Character Generator →' },
+      { href: '/character-builder?from=player-tools', label: 'Manual Builder →' },
       { href: '/roster?from=player-tools', label: 'Character Roster →' }
     ]
   },

--- a/src/components/CharacterGenerator.tsx
+++ b/src/components/CharacterGenerator.tsx
@@ -2,6 +2,23 @@
 
 import { useState, useEffect } from 'react';
 import {
+  abilities,
+  calculateCPSpent,
+  casterClasses,
+  classes,
+  createCharacterShell,
+  fnum,
+  foci,
+  magicPathsByClass,
+  races,
+  specs,
+  spendCP,
+  updateDerivedCharacterData,
+  weaknessReport,
+  mv,
+  type Character
+} from '../utils/characterBuild';
+import {
   saveCharacter,
   generateId,
   getCurrentUserId,
@@ -18,331 +35,8 @@ import {
 } from '../utils/nameGenerator';
 import { SavedCharacter, PartyFolder, PartyMembership } from '../types/party';
 
-// ======= DATA =======
-const dieRanks = ['d4', 'd6', 'd8', 'd10', 'd12'];
-const abilities = ['Competence', 'Prowess', 'Fortitude'];
-const specs = {
-  Competence: ['Adroitness', 'Expertise', 'Perception'],
-  Prowess: ['Agility', 'Melee', 'Precision'],
-  Fortitude: ['Endurance', 'Strength', 'Willpower']
-};
-const foci = {
-  Adroitness: ['Skulduggery', 'Cleverness'],
-  Expertise: ['Wizardry', 'Theurgy'],
-  Perception: ['Alertness', 'Perspicacity'],
-  Agility: ['Speed', 'Reaction'],
-  Melee: ['Threat', 'Finesse'],
-  Precision: ['Ranged Threat', 'Ranged Finesse'],
-  Endurance: ['Vitality', 'Resilience'],
-  Strength: ['Ferocity', 'Might'],
-  Willpower: ['Courage', 'Resistance']
-};
-const races = ['Human', 'Elf', 'Dwarf', 'Gnome', 'Half-Elf', 'Half-Orc', 'Halfling', 'Drakkin'];
-const classes = ['Adept', 'Assassin', 'Barbarian', 'Mage', 'Mystic', 'Rogue', 'Theurgist', 'Warrior'];
-const levels = [1, 2, 3, 4, 5];
-const casterClasses = ['Adept', 'Mage', 'Mystic', 'Theurgist'];
-const magicPathsByClass = {
-  Adept: ['Thaumaturgy', 'Elementalism', 'Sorcery'],
-  Mage: ['Thaumaturgy', 'Elementalism', 'Sorcery'],
-  Mystic: ['Mysticism'],
-  Theurgist: ['Druidry', 'Hieraticism']
-};
-const levelInfo = [
-  { level: 1, masteryDie: 'd4' },
-  { level: 2, masteryDie: 'd6' },
-  { level: 3, masteryDie: 'd8' },
-  { level: 4, masteryDie: 'd10' },
-  { level: 5, masteryDie: 'd12' }
-];
-
-const raceMinima = {
-  Drakkin: { Competence: 'd6', Prowess: 'd6', Fortitude: 'd6', Endurance: 'd6', Strength: 'd4' },
-  Dwarf: { Fortitude: 'd8', Endurance: 'd4', Prowess: 'd6', Melee: 'd6' },
-  Elf: { Competence: 'd6', Expertise: 'd6', Wizardry: '+1', Prowess: 'd4', Agility: 'd4', Reaction: '+1' },
-  Gnome: { Competence: 'd4', Adroitness: 'd6', Expertise: 'd6', Perception: 'd4', Perspicacity: '+1' },
-  'Half-Elf': { Competence: 'd6', Prowess: 'd6', Agility: 'd4', Fortitude: 'd4', Endurance: 'd4', Willpower: 'd4' },
-  'Half-Orc': { Fortitude: 'd6', Strength: 'd8', Ferocity: '+1', Endurance: 'd6' },
-  Halfling: { Competence: 'd6', Adroitness: 'd6', Cleverness: '+1', Fortitude: 'd6', Willpower: 'd4', Courage: '+1' },
-  Human: { Competence: 'd6', Prowess: 'd6', Melee: 'd4', Threat: '+1', Fortitude: 'd4', Willpower: 'd6' }
-};
-
-const classMinima = {
-  Adept: { Competence: 'd6', Adroitness: 'd4', Cleverness: '+1', Expertise: 'd6', Wizardry: '+1', Perception: 'd4', Perspicacity: '+1' },
-  Assassin: { Competence: 'd4', Adroitness: 'd6', Perception: 'd4', Prowess: 'd4', Agility: 'd4', Endurance: 'd6', Melee: 'd4', Finesse: '+1' },
-  Barbarian: { Prowess: 'd6', Melee: 'd8', Fortitude: 'd4', Strength: 'd4', Ferocity: '+1' },
-  Mage: { Competence: 'd6', Expertise: 'd8', Wizardry: '+1', Fortitude: 'd4', Willpower: 'd6', Resistance: '+1' },
-  Mystic: { Competence: 'd6', Expertise: 'd6', Wizardry: '+1', Prowess: 'd4', Melee: 'd4', Fortitude: 'd4', Endurance: 'd6', Resilience: '+1', Vitality: '+2' },
-  Rogue: { Competence: 'd4', Adroitness: 'd4', Skulduggery: '+1', Perception: 'd4', Prowess: 'd6', Agility: 'd8' },
-  Theurgist: { Competence: 'd8', Expertise: 'd4', Theurgy: '+1', Fortitude: 'd6', Willpower: 'd4' },
-  Warrior: { Prowess: 'd8', Melee: 'd6', Threat: '+1', Fortitude: 'd6' }
-};
-
-const allAdvantages = {
-  Human: ['Fortunate', 'Survival'],
-  Elf: ['Night Vision', 'Gift of Magic', 'Magic Resistance (+1)'],
-  Dwarf: ['Night Vision', 'Strong-willed', 'Sense of Direction'],
-  Gnome: ['Eidetic Memory', 'Low-Light Vision', 'Observant'],
-  'Half-Elf': ['Heightened Senses', 'Low-Light Vision', 'Magic Resistance (+1)'],
-  'Half-Orc': ['Low-light Vision', 'Intimidation', 'Menacing'],
-  Halfling: ['Low Light Vision', 'Read Emotions', 'Resilient'],
-  Drakkin: ['Natural Armor', 'Breath Weapon', 'Night Vision'],
-  Adept: ['Arcanum', 'Gift of Magic', 'Literacy', 'Scholar'],
-  Assassin: ['Expeditious', 'Heightened Senses (hearing)', 'Observant', 'Read Emotions'],
-  Barbarian: ['Animal Affinity', 'Brutishness', 'Menacing', 'Resilient'],
-  Mage: ['Arcanum', 'Gift of Magic', 'Magic Defense', 'Scholar'],
-  Mystic: ['Empathic', 'Gift of Magic', 'Intuitive', 'Magic Resistance (Lesser)', 'Strong-Willed'],
-  Rogue: ['Expeditious', 'Fortunate', 'Streetwise', 'Underworld Contacts'],
-  Theurgist: ['Gift of Magic', 'Magic Defense', 'Religion', 'Strong-Willed'],
-  Warrior: ['Commanding', 'Intimidation', 'Magic Resistance (+1)', 'Tactician']
-};
-
-const classFeats = {
-  Adept: ['Guile', 'Lore', 'Ritual Magic', 'Quick-witted'],
-  Assassin: ['Death Strike', 'Lethal Exploit', 'Ranged Ambush', 'Shadow Walk'],
-  Barbarian: ['Berserk', 'Brawl', 'Feat of Strength', 'Grapple'],
-  Mage: ['Arcane Finesse', 'Dweomers', 'Intangible Threat', 'Path Mastery'],
-  Mystic: ['Iron Mind', 'Path Mastery', 'Premonition', 'Psychic Powers'],
-  Rogue: ['Backstab', 'Evasion', 'Roguish Charm', 'Stealth'],
-  Theurgist: ['Divine Healing', 'Path Mastery', 'Spiritual Smite', 'Supernatural Intervention'],
-  Warrior: ['Battle Savvy', 'Maneuvers', 'Stunning Reversal', 'Sunder Foe']
-};
-
-const raceFlaws = {
-  Gnome: ['Restriction: small weapons only'],
-  Halfling: ['Restriction: small weapons only'],
-  'Half-Orc': ['Ugliness']
-};
-
-const startingEquipment = {
-  common: ['Set of ordinary clothes', 'Purse of 5 gold coins', 'Backpack', 'Small dagger', 'Week\'s rations', 'Waterskin', 'Tinderbox', '50\' rope', 'Iron spikes', 'Small hammer', '6\' traveling staff or 10\' pole', 'Hooded lantern and 2 oil flasks or d4+1 torches'],
-  Adept: ['Book of knowledge (area of expertise)'],
-  Assassin: ['Assassin hood, jacket, cape, robe, or tunic'],
-  Barbarian: ['Garments of woven wool or linen', 'Tunic', 'Overcoat or cloak'],
-  Mage: ['Spellbook', 'Staff or focus item'],
-  Mystic: ['Robes or shawl', 'Cloak', 'Armor up to leather'],
-  Rogue: ['Set of thieves\' tools', 'Light armor (up to leather)', 'One weapon'],
-  Theurgist: ['Prayer book', 'Holy relic or symbol', 'Focus item', 'Armor up to chain'],
-  Warrior: ['One weapon of choice', 'Armor up to chain', 'Small to large shield', 'Steed']
-};
-
-const stepCost = { 'd4': 6, 'd6': 8, 'd8': 10, 'd10': 12, 'd12': Infinity };
-const focusStepCost = 4;
-
-const classAxes = {
-  Warrior: ['Prowess', 'Melee', 'Strength', 'Fortitude', 'Endurance', 'Threat', 'Agility', 'Might'],
-  Barbarian: ['Prowess', 'Melee', 'Strength', 'Fortitude', 'Endurance', 'Ferocity', 'Might', 'Vitality'],
-  Rogue: ['Prowess', 'Agility', 'Competence', 'Adroitness', 'Perception', 'Skulduggery', 'Cleverness', 'Speed'],
-  Assassin: ['Prowess', 'Agility', 'Melee', 'Competence', 'Adroitness', 'Finesse', 'Speed', 'Perception'],
-  Mage: ['Competence', 'Expertise', 'Wizardry', 'Fortitude', 'Willpower', 'Resistance', 'Perception'],
-  Mystic: ['Fortitude', 'Willpower', 'Competence', 'Expertise', 'Endurance', 'Prowess', 'Melee', 'Resilience', 'Vitality'],
-  Adept: ['Competence', 'Expertise', 'Adroitness', 'Perception', 'Cleverness', 'Wizardry', 'Perspicacity'],
-  Theurgist: ['Competence', 'Expertise', 'Theurgy', 'Fortitude', 'Willpower', 'Endurance', 'Courage']
-};
-
-// ======= HELPERS =======
-const idx = (r: string) => dieRanks.indexOf(r);
-const mv = (r: string) => r && r.startsWith('d') ? parseInt(r.slice(1), 10) : 0;
-const fnum = (v: string | number) => v ? parseInt(String(v).replace('+', ''), 10) : 0;
-
-interface Character {
-  race: string;
-  class: string;
-  level: number;
-  abilities: Record<string, string>;
-  specialties: Record<string, Record<string, string>>;
-  focuses: Record<string, Record<string, string>>;
-  masteryDie: string;
-  advantages: string[];
-  flaws: string[];
-  classFeats: string[];
-  equipment: string[];
-  actions: Record<string, string>;
-  pools: {
-    active: number;
-    passive: number;
-    spirit: number;
-  };
-}
-
 function showAlert(message: string) {
   alert(message);
-}
-
-function getAdvantages(race: string, klass: string) {
-  const raceAdv = allAdvantages[race as keyof typeof allAdvantages] || [];
-  const classAdv = allAdvantages[klass as keyof typeof allAdvantages] || [];
-  const combined = [...new Set([...raceAdv, ...classAdv])];
-  return combined;
-}
-
-function getEquipment(klass: string) {
-  return [...startingEquipment.common, ...(startingEquipment[klass as keyof typeof startingEquipment] || [])];
-}
-
-function applyMinima(ch: Character, minima: Record<string, string>) {
-  for (const [k, v] of Object.entries(minima || {})) {
-    if (abilities.includes(k)) {
-      if (idx(v) > idx(ch.abilities[k])) ch.abilities[k] = v;
-    } else {
-      const parentA = Object.keys(specs).find(a => specs[a as keyof typeof specs].includes(k));
-      const parentS = Object.keys(foci).find(s => foci[s as keyof typeof foci].includes(k));
-      if (parentA) {
-        if (idx(v) > idx(ch.specialties[parentA][k])) ch.specialties[parentA][k] = v;
-      } else if (parentS) {
-        const pa = Object.keys(specs).find(a => specs[a as keyof typeof specs].includes(parentS));
-        if (pa && fnum(v) > fnum(ch.focuses[pa][k])) ch.focuses[pa][k] = `+${fnum(v)}`;
-      }
-    }
-  }
-}
-
-// function rookieCaps(profile: string) {
-//   if (profile === 'pure') return { abilityMax: 'd6', specMax: 'd6', focusMax: 1, rules: [(_ch: Character) => true] };
-//   if (profile === 'balanced') return { abilityMax: 'd8', specMax: 'd8', focusMax: 2, rules: [(ch: Character) => breadthFloors(ch, 'd6')] };
-//   if (profile === 'specialist') return { abilityMax: 'd8', specMax: 'd10', focusMax: 3, rules: [(ch: Character) => floors(ch, 'd4')] };
-//   return null;
-// }
-
-// function softCaps(level: number, style: string) {
-//   const sc = { abilityMax: 'd12', specMax: 'd12', focusMax: 5, rules: [] as ((ch: Character) => boolean)[] };
-//   if (style === 'balanced') {
-//     if (level <= 3) { sc.abilityMax = 'd10'; sc.specMax = 'd10'; sc.focusMax = 3; }
-//     if (level === 4) { sc.focusMax = 4; }
-//     sc.rules.push((ch: Character) => breadthFloors(ch, 'd8'));
-//     sc.rules.push((ch: Character) => countSpecsAtOrAbove(ch, 'd12') <= 1);
-//   }
-//   if (style === 'hybrid' && level <= 3) sc.focusMax = 4;
-//   if (style === 'specialist') {
-//     if (level <= 3) sc.focusMax = 5;
-//     sc.rules.push((ch: Character) => floors(ch, 'd4'));
-//   }
-//   return sc;
-// }
-
-function buildWeights(klass: string, style: string) {
-  const axis = classAxes[klass as keyof typeof classAxes] || [];
-  const w: Record<string, number> = {};
-  axis.forEach((k, i) => w[k] = (style === 'specialist' ? 100 - i * 4 : style === 'balanced' ? 60 - i * 3 : 80 - i * 3));
-  if (style === 'balanced') {
-    w['Competence'] = (w['Competence'] || 30) + 20;
-    w['Fortitude'] = (w['Fortitude'] || 30) + 20;
-    ['Endurance', 'Strength', 'Willpower', 'Agility'].forEach(k => w[k] = (w[k] || 20) + 10);
-  }
-  return w;
-}
-
-function canUpgrade(ch: Character, key: string, kind: string, level: number, style: string, enforceSoftcaps: boolean) {
-  if (!enforceSoftcaps) return true;
-  // For now, simplified - could add full validation later
-  return true;
-}
-
-function spendCP(ch: Character, cpBudget: { value: number }, style: string, level: number, npcMode: boolean, enforceSoftcaps: boolean) {
-  const weights = buildWeights(ch.class, style);
-  const tryUpgrade = (key: string) => {
-    if (abilities.includes(key)) {
-      const cur = ch.abilities[key];
-      if (cur === 'd12') return false;
-      if (!canUpgrade(ch, key, 'ability', level, style, enforceSoftcaps)) return false;
-      const cost = stepCost[cur as keyof typeof stepCost];
-      if (cpBudget.value < cost) return false;
-      ch.abilities[key] = dieRanks[idx(cur) + 1];
-      cpBudget.value -= cost;
-      return true;
-    }
-    const pa = Object.keys(specs).find(a => specs[a as keyof typeof specs].includes(key));
-    if (pa) {
-      const cur = ch.specialties[pa][key];
-      if (cur === 'd12') return false;
-      if (!canUpgrade(ch, key, 'spec', level, style, enforceSoftcaps)) return false;
-      const cost = stepCost[cur as keyof typeof stepCost];
-      if (cpBudget.value < cost) return false;
-      ch.specialties[pa][key] = dieRanks[idx(cur) + 1];
-      cpBudget.value -= cost;
-      return true;
-    }
-    const ps = Object.keys(foci).find(s => foci[s as keyof typeof foci].includes(key));
-    if (ps) {
-      const pa2 = Object.keys(specs).find(a => specs[a as keyof typeof specs].includes(ps));
-      if (pa2) {
-        const val = fnum(ch.focuses[pa2][key]);
-        if (val >= 5) return false; // max focus
-        if (cpBudget.value < focusStepCost) return false;
-        ch.focuses[pa2][key] = `+${val + 1}`;
-        cpBudget.value -= focusStepCost;
-        return true;
-      }
-    }
-    return false;
-  };
-  const keys = [...new Set([...abilities, ...Object.values(specs).flat(), ...Object.values(foci).flat()])];
-  let safety = 0;
-  while (cpBudget.value > 0 && safety < 5000) {
-    safety++;
-    const sorted = keys.slice().sort((a, b) => (weights[b] || 10) - (weights[a] || 10));
-    let upgraded = false;
-    for (const k of sorted) {
-      if (tryUpgrade(k)) {
-        upgraded = true;
-        break;
-      }
-    }
-    if (!upgraded) break;
-  }
-}
-
-function computePools(ch: Character) {
-  const AD = mv(ch.abilities.Prowess) + mv(ch.specialties.Prowess.Agility) + mv(ch.specialties.Prowess.Melee);
-  const PD = mv(ch.abilities.Fortitude) + mv(ch.specialties.Fortitude.Endurance) + mv(ch.specialties.Fortitude.Strength);
-  const SP = mv(ch.abilities.Competence) + mv(ch.specialties.Fortitude.Willpower);
-  return { active: AD, passive: PD, spirit: SP };
-}
-
-function weaknessReport(ch: Character) {
-  const { active, passive, spirit } = computePools(ch);
-  const flags = [];
-  if (spirit <= 12) flags.push('Low Spirit Points (mental/arcane pressure will hurt).');
-  if (active < 24) flags.push('Low Active DP (poor agility/parry).');
-  if (passive < 24) flags.push('Low Passive DP (fragile to heavy blows).');
-  if (idx(ch.abilities.Competence) <= 1) flags.push('Low Competence (poor perception/social/planning).');
-  if (idx(ch.specialties.Competence.Perception) <= 1) flags.push('Low Perception branch (traps/ambush risk).');
-  if (idx(ch.specialties.Fortitude.Willpower) <= 1) flags.push('Low Willpower (charms/fear/illusions).');
-  if (idx(ch.specialties.Prowess.Precision) <= 1) flags.push('Weak ranged capability.');
-  return flags;
-}
-
-function calculateCPSpent(finalChar: Character, baseChar: Character, iconic: boolean) {
-  const spent = { abilities: 0, specialties: 0, focuses: 0, advantages: 0, total: 0 };
-  spent.advantages = iconic ? 4 : 0;
-
-  for (const ab of abilities) {
-    const baseRankIndex = idx(baseChar.abilities[ab]);
-    const finalRankIndex = idx(finalChar.abilities[ab]);
-    for (let i = baseRankIndex; i < finalRankIndex; i++) {
-      spent.abilities += stepCost[dieRanks[i] as keyof typeof stepCost];
-    }
-
-    for (const sp of specs[ab as keyof typeof specs]) {
-      const baseSpecIndex = idx(baseChar.specialties[ab][sp]);
-      const finalSpecIndex = idx(finalChar.specialties[ab][sp]);
-      for (let i = baseSpecIndex; i < finalSpecIndex; i++) {
-        spent.specialties += stepCost[dieRanks[i] as keyof typeof stepCost];
-      }
-    }
-
-    Object.keys(foci).forEach(specKey => {
-      if (specs[ab as keyof typeof specs].includes(specKey)) {
-        foci[specKey as keyof typeof foci].forEach(focusKey => {
-          const baseFocusValue = fnum(baseChar.focuses[ab][focusKey]);
-          const finalFocusValue = fnum(finalChar.focuses[ab][focusKey]);
-          spent.focuses += (finalFocusValue - baseFocusValue) * focusStepCost;
-        });
-      }
-    });
-  }
-
-  spent.total = 10 + spent.abilities + spent.specialties + spent.focuses + spent.advantages;
-  return spent;
 }
 
 export default function CharacterGenerator() {
@@ -411,39 +105,7 @@ export default function CharacterGenerator() {
       return;
     }
 
-    const ch: Character = {
-      race,
-      class: characterClass,
-      level,
-      abilities: {},
-      specialties: {},
-      focuses: {},
-      masteryDie: '',
-      advantages: [],
-      flaws: [],
-      classFeats: [],
-      equipment: [],
-      actions: {},
-      pools: { active: 0, passive: 0, spirit: 0 }
-    };
-
-    for (const a of abilities) {
-      ch.abilities[a] = 'd4';
-      ch.specialties[a] = {};
-      ch.focuses[a] = {};
-      for (const s of specs[a as keyof typeof specs]) {
-        ch.specialties[a][s] = 'd4';
-        for (const fx of foci[s as keyof typeof foci]) {
-          ch.focuses[a][fx] = '+0';
-        }
-      }
-    }
-
-    const baseCharacter = JSON.parse(JSON.stringify(ch));
-    applyMinima(baseCharacter, raceMinima[race as keyof typeof raceMinima]);
-    applyMinima(baseCharacter, classMinima[characterClass as keyof typeof classMinima]);
-
-    Object.assign(ch, JSON.parse(JSON.stringify(baseCharacter)));
+    const { character: ch, baseCharacter } = createCharacterShell(race, characterClass, level);
 
     const cpBudgetVal = (level === 1 && rookieProfile !== 'off') ? 10 : 10 + (level - 1) * 100;
     const cpBudget = { value: cpBudgetVal };
@@ -462,22 +124,8 @@ export default function CharacterGenerator() {
       spendCP(ch, cpBudget, buildStyle, level, false, enforceSoftcaps);
     }
 
-    ch.masteryDie = levelInfo[level - 1].masteryDie;
-    ch.advantages = getAdvantages(race, characterClass);
-    ch.flaws = raceFlaws[race as keyof typeof raceFlaws] || [];
-    ch.classFeats = classFeats[characterClass as keyof typeof classFeats] || [];
-    ch.equipment = getEquipment(characterClass);
+    updateDerivedCharacterData(ch);
 
-    const w = fnum(ch.focuses.Competence.Wizardry);
-    const t = fnum(ch.focuses.Competence.Theurgy);
-    ch.actions = {
-      meleeAttack: `${ch.abilities.Prowess} + ${ch.specialties.Prowess.Melee}` + (fnum(ch.focuses.Prowess.Threat) ? ` + Threat +${fnum(ch.focuses.Prowess.Threat)}` : ''),
-      rangedAttack: `${ch.abilities.Prowess} + ${ch.specialties.Prowess.Precision}` + (fnum(ch.focuses.Prowess['Ranged Threat']) ? ` + Ranged Threat +${fnum(ch.focuses.Prowess['Ranged Threat'])}` : ''),
-      perceptionCheck: `${ch.abilities.Competence} + ${ch.specialties.Competence.Perception}` + (fnum(ch.focuses.Competence.Perspicacity) ? ` + Perspicacity +${fnum(ch.focuses.Competence.Perspicacity)}` : ''),
-      magicAttack: casterClasses.includes(characterClass) ? `${ch.abilities.Competence} + ${ch.specialties.Competence.Expertise} + ${(w ? `Wizardry +${w}` : t ? `Theurgy +${t}` : '(path focus 0)')}` : '—'
-    };
-
-    ch.pools = computePools(ch);
     const spentTotals = calculateCPSpent(ch, baseCharacter, iconicArcane);
     setCharacter(ch);
     setLastCharacter({ ch, base: baseCharacter, iconic: iconicArcane, style: buildStyle, rp: rookieProfile, spent: spentTotals });

--- a/src/components/ManualCharacterBuilder.tsx
+++ b/src/components/ManualCharacterBuilder.tsx
@@ -1,0 +1,588 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  abilities,
+  calculateCPSpent,
+  classes,
+  createCharacterShell,
+  deepCloneCharacter,
+  dieRanks,
+  fnum,
+  foci,
+  magicPathsByClass,
+  races,
+  specs,
+  updateDerivedCharacterData,
+  weaknessReport,
+  mv,
+  type Character
+} from '../utils/characterBuild';
+import {
+  saveCharacter,
+  generateId,
+  getCurrentUserId,
+  getAllPartyFolders,
+  savePartyMembership,
+  getPartyMemberships
+} from '../utils/partyStorage';
+import {
+  generateRandomName,
+  getNameSuggestionsForCharacter,
+  Gender,
+  NameCulture,
+  RACE_CULTURE_MAP
+} from '../utils/nameGenerator';
+import { SavedCharacter, PartyFolder, PartyMembership } from '../types/party';
+
+interface CPBreakdown {
+  abilities: number;
+  specialties: number;
+  focuses: number;
+  advantages: number;
+  total: number;
+}
+
+const levels = [1, 2, 3, 4, 5];
+
+const getBudgetForLevel = (level: number) => (level === 1 ? 10 : 10 + (level - 1) * 100);
+
+export default function ManualCharacterBuilder() {
+  const [selectedRace, setSelectedRace] = useState('');
+  const [selectedClass, setSelectedClass] = useState('');
+  const [selectedLevel, setSelectedLevel] = useState<number>(1);
+  const [selectedMagicPath, setSelectedMagicPath] = useState('');
+
+  const [character, setCharacter] = useState<Character | null>(null);
+  const [baseCharacter, setBaseCharacter] = useState<Character | null>(null);
+  const [cpSpent, setCpSpent] = useState<CPBreakdown | null>(null);
+
+  const [pcName, setPcName] = useState('');
+  const [playerName, setPlayerName] = useState('');
+  const [characterGender, setCharacterGender] = useState<Gender>('Male');
+  const [nameCulture, setNameCulture] = useState<NameCulture>('English');
+  const [suggestedNames, setSuggestedNames] = useState<Array<{ firstName: string; familyName?: string; culture: NameCulture; suggestion: string }>>([]);
+
+  const [partyFolders, setPartyFolders] = useState<PartyFolder[]>([]);
+  const [selectedParty, setSelectedParty] = useState('');
+  const [showPartyAssignment, setShowPartyAssignment] = useState(false);
+
+  useEffect(() => {
+    const pcFolders = getAllPartyFolders().filter(folder => folder.folder_type === 'PC_party');
+    setPartyFolders(pcFolders);
+  }, []);
+
+  useEffect(() => {
+    if (character?.race && RACE_CULTURE_MAP[character.race]) {
+      setNameCulture(RACE_CULTURE_MAP[character.race]);
+    }
+  }, [character?.race]);
+
+  useEffect(() => {
+    if (character?.race && character?.class) {
+      const suggestions = getNameSuggestionsForCharacter(character.race, character.class, characterGender, 5);
+      setSuggestedNames(suggestions);
+    }
+  }, [character?.race, character?.class, characterGender]);
+
+  const cpBudget = useMemo(() => getBudgetForLevel(selectedLevel), [selectedLevel]);
+
+  useEffect(() => {
+    if (selectedRace && selectedClass) {
+      const { character: workingCharacter, baseCharacter: minimaCharacter } = createCharacterShell(selectedRace, selectedClass, selectedLevel);
+      updateDerivedCharacterData(workingCharacter);
+      setCharacter(workingCharacter);
+      setBaseCharacter(minimaCharacter);
+      setCpSpent(calculateCPSpent(workingCharacter, minimaCharacter, false));
+    } else {
+      setCharacter(null);
+      setBaseCharacter(null);
+      setCpSpent(null);
+    }
+  }, [selectedRace, selectedClass, selectedLevel]);
+
+  useEffect(() => {
+    setCharacter(prev => {
+      if (!prev) return prev;
+      const next = deepCloneCharacter(prev);
+      (next as Record<string, unknown>).magicPath = selectedMagicPath;
+      return next;
+    });
+  }, [selectedMagicPath]);
+
+  const applyCharacterUpdate = (updater: (draft: Character) => void) => {
+    if (!character || !baseCharacter) return;
+    const next = deepCloneCharacter(character);
+    updater(next);
+    updateDerivedCharacterData(next);
+    setCharacter(next);
+    setCpSpent(calculateCPSpent(next, baseCharacter, false));
+  };
+
+  const adjustAbility = (ability: string, delta: number) => {
+    if (!character || !baseCharacter) return;
+    const currentIndex = dieRanks.indexOf(character.abilities[ability]);
+    const minIndex = dieRanks.indexOf(baseCharacter.abilities[ability]);
+    const nextIndex = currentIndex + delta;
+    if (nextIndex < minIndex || nextIndex < 0 || nextIndex >= dieRanks.length) return;
+    applyCharacterUpdate(draft => {
+      draft.abilities[ability] = dieRanks[nextIndex];
+    });
+  };
+
+  const adjustSpecialty = (ability: string, specialty: string, delta: number) => {
+    if (!character || !baseCharacter) return;
+    const currentIndex = dieRanks.indexOf(character.specialties[ability][specialty]);
+    const minIndex = dieRanks.indexOf(baseCharacter.specialties[ability][specialty]);
+    const nextIndex = currentIndex + delta;
+    if (nextIndex < minIndex || nextIndex < 0 || nextIndex >= dieRanks.length) return;
+    applyCharacterUpdate(draft => {
+      draft.specialties[ability][specialty] = dieRanks[nextIndex];
+    });
+  };
+
+  const adjustFocus = (ability: string, specialty: string, focusKey: string, delta: number) => {
+    if (!character || !baseCharacter) return;
+    const currentValue = fnum(character.focuses[ability][focusKey]);
+    const minValue = fnum(baseCharacter.focuses[ability][focusKey]);
+    const nextValue = currentValue + delta;
+    if (nextValue < minValue || nextValue < 0 || nextValue > 5) return;
+    applyCharacterUpdate(draft => {
+      draft.focuses[ability][focusKey] = `+${nextValue}`;
+    });
+  };
+
+  const cpRemaining = useMemo(() => {
+    if (!cpSpent) return cpBudget;
+    return cpBudget - cpSpent.total;
+  }, [cpBudget, cpSpent]);
+
+  const cpWarning = cpRemaining < 0 ? `You have overspent by ${Math.abs(cpRemaining)} CP.` : null;
+  const weaknessWarnings = character ? weaknessReport(character) : [];
+  const combinedWarnings = [cpWarning, ...weaknessWarnings].filter(Boolean) as string[];
+  const canFinalize = Boolean(character && baseCharacter && cpRemaining >= 0);
+
+  const resetBuilder = () => {
+    setSelectedRace('');
+    setSelectedClass('');
+    setSelectedMagicPath('');
+    setCharacter(null);
+    setBaseCharacter(null);
+    setCpSpent(null);
+  };
+
+  const saveCharacterToRoster = () => {
+    if (!character) return;
+    setShowPartyAssignment(true);
+  };
+
+  const confirmSaveCharacter = () => {
+    if (!character) return;
+    const charName = pcName.trim() || prompt('Enter character name:', `${character.race} ${character.class}`);
+    if (!charName) return;
+
+    const savedChar: SavedCharacter = {
+      id: generateId(),
+      user_id: getCurrentUserId(),
+      name: charName.trim(),
+      type: 'PC',
+      level: character.level,
+      race: character.race,
+      class: character.class,
+      abilities: {
+        prowess_mv: mv(character.abilities.Prowess),
+        agility_mv: mv(character.specialties.Prowess.Agility),
+        melee_mv: mv(character.specialties.Prowess.Melee),
+        fortitude_mv: mv(character.abilities.Fortitude),
+        endurance_mv: mv(character.specialties.Fortitude.Endurance),
+        strength_mv: mv(character.specialties.Fortitude.Strength),
+        competence_mv: mv(character.abilities.Competence),
+        willpower_mv: mv(character.specialties.Fortitude.Willpower),
+        expertise_mv: mv(character.specialties.Competence.Expertise),
+        perception_mv: mv(character.specialties.Competence.Perception),
+        adroitness_mv: mv(character.specialties.Competence.Adroitness),
+        precision_mv: mv(character.specialties.Prowess.Precision)
+      },
+      computed: {
+        active_dp: character.pools.active,
+        passive_dp: character.pools.passive,
+        spirit_pts: character.pools.spirit
+      },
+      status: {
+        current_hp_active: character.pools.active,
+        current_hp_passive: character.pools.passive,
+        status_flags: [],
+        gear: character.equipment || [],
+        notes: playerName ? `Player: ${playerName}` : ''
+      },
+      tags: ['Manual Build', `Level ${character.level}`, characterGender],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      full_data: {
+        ...character as unknown as Record<string, unknown>,
+        player_name: playerName,
+        character_gender: characterGender,
+        name_culture: nameCulture,
+        magic_path: selectedMagicPath,
+        build_method: 'manual'
+      }
+    };
+
+    saveCharacter(savedChar);
+
+    if (selectedParty) {
+      const existingMemberships = getPartyMemberships(selectedParty);
+      const membership: PartyMembership = {
+        id: generateId(),
+        party_id: selectedParty,
+        character_id: savedChar.id,
+        order_index: existingMemberships.length,
+        active: true
+      };
+      savePartyMembership(membership);
+      const partyName = partyFolders.find(f => f.id === selectedParty)?.name || 'party';
+      alert(`${savedChar.name} added to ${partyName}!`);
+    } else {
+      alert(`${savedChar.name} saved to roster!`);
+    }
+
+    setShowPartyAssignment(false);
+  };
+
+  const handleRandomName = () => {
+    if (!character) return;
+    const randomName = generateRandomName(character.race, characterGender, nameCulture);
+    setPcName(randomName);
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-10">
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">Manual Character Builder</h1>
+          <p className="text-sm text-gray-600">Plan every CP by hand to create bespoke heroes. Choose race, class, and level, then allocate abilities, specialties, and focuses within your budget.</p>
+        </div>
+        <button
+          onClick={resetBuilder}
+          className="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-4">
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="race">Race</label>
+            <select
+              id="race"
+              className="w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5"
+              value={selectedRace}
+              onChange={(e) => setSelectedRace(e.target.value)}
+            >
+              <option value="">Select Race</option>
+              {races.map(race => <option key={race} value={race}>{race}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="class">Class</label>
+            <select
+              id="class"
+              className="w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5"
+              value={selectedClass}
+              onChange={(e) => {
+                setSelectedClass(e.target.value);
+                setSelectedMagicPath('');
+              }}
+            >
+              <option value="">Select Class</option>
+              {classes.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1" htmlFor="level">Level</label>
+            <select
+              id="level"
+              className="w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5"
+              value={selectedLevel}
+              onChange={(e) => setSelectedLevel(parseInt(e.target.value))}
+            >
+              {levels.map(level => <option key={level} value={level}>{level}</option>)}
+            </select>
+          </div>
+          {selectedClass && magicPathsByClass[selectedClass] && selectedClass !== 'Adept' && selectedClass !== 'Mystic' && (
+            <div>
+              <label className="block text-sm font-medium mb-1" htmlFor="magic-path">Magic Path</label>
+              <select
+                id="magic-path"
+                className="w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5"
+                value={selectedMagicPath}
+                onChange={(e) => setSelectedMagicPath(e.target.value)}
+              >
+                <option value="">Select Path</option>
+                {magicPathsByClass[selectedClass]?.map(path => <option key={path} value={path}>{path}</option>)}
+              </select>
+            </div>
+          )}
+        </div>
+
+        <div className="lg:col-span-3 space-y-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="bg-white border border-gray-200 rounded-xl p-4">
+              <div className="text-sm text-gray-500">CP Budget</div>
+              <div className="text-2xl font-bold">{cpBudget}</div>
+            </div>
+            <div className="bg-white border border-gray-200 rounded-xl p-4">
+              <div className="text-sm text-gray-500">CP Spent</div>
+              <div className="text-2xl font-bold">{cpSpent?.total ?? 0}</div>
+            </div>
+            <div className={`border rounded-xl p-4 ${cpRemaining < 0 ? 'border-red-300 bg-red-50' : 'border-gray-200 bg-white'}`}>
+              <div className="text-sm text-gray-500">CP Remaining</div>
+              <div className={`text-2xl font-bold ${cpRemaining < 0 ? 'text-red-600' : ''}`}>{cpRemaining}</div>
+            </div>
+          </div>
+
+          {combinedWarnings.length > 0 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4 text-sm text-yellow-800 space-y-1">
+              {combinedWarnings.map((warning, index) => (
+                <div key={`${warning}-${index}`}>{warning}</div>
+              ))}
+            </div>
+          )}
+
+          {character ? (
+            <div className="space-y-4">
+              <div className="bg-white border border-gray-200 rounded-xl p-4">
+                <h2 className="text-lg font-semibold mb-3">Abilities & Specialties</h2>
+                <div className="space-y-4">
+                  {abilities.map(ability => (
+                    <div key={ability} className="border border-gray-200 rounded-lg">
+                      <div className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-t-lg">
+                        <div>
+                          <div className="text-sm font-semibold">{ability}</div>
+                          <div className="text-xs text-gray-500">Minimum: {baseCharacter?.abilities[ability]}</div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            className="w-8 h-8 rounded-full border border-gray-300 bg-white text-gray-700"
+                            onClick={() => adjustAbility(ability, -1)}
+                          >
+                            −
+                          </button>
+                          <span className="font-mono text-lg">{character.abilities[ability]}</span>
+                          <button
+                            className="w-8 h-8 rounded-full border border-gray-300 bg-white text-gray-700"
+                            onClick={() => adjustAbility(ability, 1)}
+                          >
+                            +
+                          </button>
+                        </div>
+                      </div>
+                      <div className="px-4 py-3 space-y-3">
+                        {specs[ability as keyof typeof specs].map(spec => (
+                          <div key={spec} className="border border-gray-100 rounded-lg p-3">
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <div className="text-sm font-medium">{spec}</div>
+                                <div className="text-xs text-gray-500">Minimum: {baseCharacter?.specialties[ability][spec]}</div>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <button
+                                  className="w-7 h-7 rounded-full border border-gray-300 bg-white text-gray-700"
+                                  onClick={() => adjustSpecialty(ability, spec, -1)}
+                                >
+                                  −
+                                </button>
+                                <span className="font-mono">{character.specialties[ability][spec]}</span>
+                                <button
+                                  className="w-7 h-7 rounded-full border border-gray-300 bg-white text-gray-700"
+                                  onClick={() => adjustSpecialty(ability, spec, 1)}
+                                >
+                                  +
+                                </button>
+                              </div>
+                            </div>
+                            <div className="grid gap-2 mt-3 md:grid-cols-2">
+                              {foci[spec as keyof typeof foci].map(focusKey => (
+                                <div key={focusKey} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2">
+                                  <div>
+                                    <div className="text-sm font-medium">{focusKey}</div>
+                                    <div className="text-xs text-gray-500">Minimum: +{fnum(baseCharacter?.focuses[ability][focusKey] ?? '+0')}</div>
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    <button
+                                      className="w-6 h-6 rounded-full border border-gray-300 bg-white text-gray-700"
+                                      onClick={() => adjustFocus(ability, spec, focusKey, -1)}
+                                    >
+                                      −
+                                    </button>
+                                    <span className="font-mono">{character.focuses[ability][focusKey]}</span>
+                                    <button
+                                      className="w-6 h-6 rounded-full border border-gray-300 bg-white text-gray-700"
+                                      onClick={() => adjustFocus(ability, spec, focusKey, 1)}
+                                    >
+                                      +
+                                    </button>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="bg-white border border-gray-200 rounded-xl p-4">
+                  <div className="text-sm text-gray-500">Mastery Die</div>
+                  <div className="text-xl font-semibold">{character.masteryDie}</div>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-xl p-4">
+                  <div className="text-sm text-gray-500">Advantages</div>
+                  <ul className="text-sm list-disc pl-5 mt-1 space-y-1">
+                    {character.advantages.map(adv => <li key={adv}>{adv}</li>)}
+                  </ul>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-xl p-4">
+                  <div className="text-sm text-gray-500">Equipment</div>
+                  <ul className="text-sm list-disc pl-5 mt-1 space-y-1">
+                    {character.equipment.map(item => <li key={item}>{item}</li>)}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="bg-white border border-gray-200 rounded-xl p-4">
+                <h3 className="font-semibold mb-3">Name & Player Info</h3>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className="block text-sm font-medium mb-1" htmlFor="pc-name">Character Name</label>
+                    <input
+                      id="pc-name"
+                      value={pcName}
+                      onChange={(e) => setPcName(e.target.value)}
+                      className="w-full rounded-lg border border-gray-300 p-2.5"
+                      placeholder="Enter name"
+                    />
+                    <div className="flex gap-2 mt-2">
+                      <button
+                        onClick={handleRandomName}
+                        className="text-xs px-3 py-1.5 rounded-full border border-gray-300 text-gray-600 hover:bg-gray-100"
+                      >
+                        Random Name
+                      </button>
+                      <select
+                        value={nameCulture}
+                        onChange={(e) => setNameCulture(e.target.value as NameCulture)}
+                        className="text-xs rounded-full border border-gray-300 px-3 py-1.5"
+                      >
+                        {Object.keys(RACE_CULTURE_MAP).map(culture => (
+                          <option key={culture} value={culture}>{culture}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1" htmlFor="player-name">Player Name</label>
+                    <input
+                      id="player-name"
+                      value={playerName}
+                      onChange={(e) => setPlayerName(e.target.value)}
+                      className="w-full rounded-lg border border-gray-300 p-2.5"
+                      placeholder="Optional"
+                    />
+                    <div className="flex gap-3 mt-3 text-sm">
+                      {(['Male', 'Female'] as Gender[]).map(g => (
+                        <label key={g} className="flex items-center gap-1">
+                          <input
+                            type="radio"
+                            value={g}
+                            checked={characterGender === g}
+                            onChange={(e) => setCharacterGender(e.target.value as Gender)}
+                          />
+                          {g}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                {suggestedNames.length > 0 && (
+                  <div className="mt-3">
+                    <div className="text-xs font-semibold text-gray-500 uppercase">Suggestions</div>
+                    <div className="flex flex-wrap gap-2 mt-2">
+                      {suggestedNames.map(name => (
+                        <button
+                          key={name.suggestion}
+                          onClick={() => setPcName(name.suggestion)}
+                          className="text-xs rounded-full border border-gray-300 px-3 py-1 hover:bg-gray-100"
+                        >
+                          {name.suggestion}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  className="rounded-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2.5 px-6 shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={saveCharacterToRoster}
+                  disabled={!canFinalize}
+                >
+                  Save to Roster
+                </button>
+                <button
+                  className="rounded-full border border-gray-300 px-6 py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-100"
+                  onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                >
+                  Back to Top
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="bg-white border border-dashed border-gray-300 rounded-xl p-6 text-center text-gray-500">
+              Choose a race, class, and level to start allocating CP.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showPartyAssignment && character && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-lg space-y-4">
+            <h3 className="text-lg font-semibold">Assign to Party</h3>
+            <p className="text-sm text-gray-600">Optionally choose a party folder for this character.</p>
+            <select
+              className="w-full rounded-lg border border-gray-300 p-2.5"
+              value={selectedParty}
+              onChange={(e) => setSelectedParty(e.target.value)}
+            >
+              <option value="">No Party Assignment</option>
+              {partyFolders.map(folder => (
+                <option key={folder.id} value={folder.id}>{folder.name}</option>
+              ))}
+            </select>
+            <div className="flex justify-end gap-3">
+              <button
+                className="px-4 py-2 text-sm rounded-full border border-gray-300"
+                onClick={() => setShowPartyAssignment(false)}
+              >
+                Cancel
+              </button>
+              <button
+                className="px-4 py-2 text-sm rounded-full bg-blue-600 text-white font-medium hover:bg-blue-700"
+                onClick={confirmSaveCharacter}
+                disabled={!canFinalize}
+              >
+                Confirm Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/utils/characterBuild.ts
+++ b/src/utils/characterBuild.ts
@@ -1,0 +1,395 @@
+export const dieRanks = ['d4', 'd6', 'd8', 'd10', 'd12'] as const;
+export type DieRank = typeof dieRanks[number];
+
+export const abilities = ['Competence', 'Prowess', 'Fortitude'] as const;
+export type Ability = typeof abilities[number];
+
+export const specs = {
+  Competence: ['Adroitness', 'Expertise', 'Perception'],
+  Prowess: ['Agility', 'Melee', 'Precision'],
+  Fortitude: ['Endurance', 'Strength', 'Willpower']
+} as const;
+export type Specialty = (typeof specs)[keyof typeof specs][number];
+
+export const foci = {
+  Adroitness: ['Skulduggery', 'Cleverness'],
+  Expertise: ['Wizardry', 'Theurgy'],
+  Perception: ['Alertness', 'Perspicacity'],
+  Agility: ['Speed', 'Reaction'],
+  Melee: ['Threat', 'Finesse'],
+  Precision: ['Ranged Threat', 'Ranged Finesse'],
+  Endurance: ['Vitality', 'Resilience'],
+  Strength: ['Ferocity', 'Might'],
+  Willpower: ['Courage', 'Resistance']
+} as const;
+export type Focus = typeof foci[keyof typeof foci][number];
+
+export const races = ['Human', 'Elf', 'Dwarf', 'Gnome', 'Half-Elf', 'Half-Orc', 'Halfling', 'Drakkin'] as const;
+export const classes = ['Adept', 'Assassin', 'Barbarian', 'Mage', 'Mystic', 'Rogue', 'Theurgist', 'Warrior'] as const;
+export const levels = [1, 2, 3, 4, 5] as const;
+
+export const casterClasses = ['Adept', 'Mage', 'Mystic', 'Theurgist'] as const;
+
+export const magicPathsByClass: Record<string, string[]> = {
+  Adept: ['Thaumaturgy', 'Elementalism', 'Sorcery'],
+  Mage: ['Thaumaturgy', 'Elementalism', 'Sorcery'],
+  Mystic: ['Mysticism'],
+  Theurgist: ['Druidry', 'Hieraticism']
+};
+
+export const levelInfo = [
+  { level: 1, masteryDie: 'd4' },
+  { level: 2, masteryDie: 'd6' },
+  { level: 3, masteryDie: 'd8' },
+  { level: 4, masteryDie: 'd10' },
+  { level: 5, masteryDie: 'd12' }
+];
+
+export const raceMinima: Record<string, Record<string, string>> = {
+  Drakkin: { Competence: 'd6', Prowess: 'd6', Fortitude: 'd6', Endurance: 'd6', Strength: 'd4' },
+  Dwarf: { Fortitude: 'd8', Endurance: 'd4', Prowess: 'd6', Melee: 'd6' },
+  Elf: { Competence: 'd6', Expertise: 'd6', Wizardry: '+1', Prowess: 'd4', Agility: 'd4', Reaction: '+1' },
+  Gnome: { Competence: 'd4', Adroitness: 'd6', Expertise: 'd6', Perception: 'd4', Perspicacity: '+1' },
+  'Half-Elf': { Competence: 'd6', Prowess: 'd6', Agility: 'd4', Fortitude: 'd4', Endurance: 'd4', Willpower: 'd4' },
+  'Half-Orc': { Fortitude: 'd6', Strength: 'd8', Ferocity: '+1', Endurance: 'd6' },
+  Halfling: { Competence: 'd6', Adroitness: 'd6', Cleverness: '+1', Fortitude: 'd6', Willpower: 'd4', Courage: '+1' },
+  Human: { Competence: 'd6', Prowess: 'd6', Melee: 'd4', Threat: '+1', Fortitude: 'd4', Willpower: 'd6' }
+};
+
+export const classMinima: Record<string, Record<string, string>> = {
+  Adept: { Competence: 'd6', Adroitness: 'd4', Cleverness: '+1', Expertise: 'd6', Wizardry: '+1', Perception: 'd4', Perspicacity: '+1' },
+  Assassin: { Competence: 'd4', Adroitness: 'd6', Perception: 'd4', Prowess: 'd4', Agility: 'd4', Endurance: 'd6', Melee: 'd4', Finesse: '+1' },
+  Barbarian: { Prowess: 'd6', Melee: 'd8', Fortitude: 'd4', Strength: 'd4', Ferocity: '+1' },
+  Mage: { Competence: 'd6', Expertise: 'd8', Wizardry: '+1', Fortitude: 'd4', Willpower: 'd6', Resistance: '+1' },
+  Mystic: { Competence: 'd6', Expertise: 'd6', Wizardry: '+1', Prowess: 'd4', Melee: 'd4', Fortitude: 'd4', Endurance: 'd6', Resilience: '+1', Vitality: '+2' },
+  Rogue: { Competence: 'd4', Adroitness: 'd4', Skulduggery: '+1', Perception: 'd4', Prowess: 'd6', Agility: 'd8' },
+  Theurgist: { Competence: 'd8', Expertise: 'd4', Theurgy: '+1', Fortitude: 'd6', Willpower: 'd4' },
+  Warrior: { Prowess: 'd8', Melee: 'd6', Threat: '+1', Fortitude: 'd6' }
+};
+
+export const allAdvantages: Record<string, string[]> = {
+  Human: ['Fortunate', 'Survival'],
+  Elf: ['Night Vision', 'Gift of Magic', 'Magic Resistance (+1)'],
+  Dwarf: ['Night Vision', 'Strong-willed', 'Sense of Direction'],
+  Gnome: ['Eidetic Memory', 'Low-Light Vision', 'Observant'],
+  'Half-Elf': ['Heightened Senses', 'Low-Light Vision', 'Magic Resistance (+1)'],
+  'Half-Orc': ['Low-light Vision', 'Intimidation', 'Menacing'],
+  Halfling: ['Low Light Vision', 'Read Emotions', 'Resilient'],
+  Drakkin: ['Natural Armor', 'Breath Weapon', 'Night Vision'],
+  Adept: ['Arcanum', 'Gift of Magic', 'Literacy', 'Scholar'],
+  Assassin: ['Expeditious', 'Heightened Senses (hearing)', 'Observant', 'Read Emotions'],
+  Barbarian: ['Animal Affinity', 'Brutishness', 'Menacing', 'Resilient'],
+  Mage: ['Arcanum', 'Gift of Magic', 'Magic Defense', 'Scholar'],
+  Mystic: ['Empathic', 'Gift of Magic', 'Intuitive', 'Magic Resistance (Lesser)', 'Strong-Willed'],
+  Rogue: ['Expeditious', 'Fortunate', 'Streetwise', 'Underworld Contacts'],
+  Theurgist: ['Gift of Magic', 'Magic Defense', 'Religion', 'Strong-Willed'],
+  Warrior: ['Commanding', 'Intimidation', 'Magic Resistance (+1)', 'Tactician']
+};
+
+export const classFeats: Record<string, string[]> = {
+  Adept: ['Guile', 'Lore', 'Ritual Magic', 'Quick-witted'],
+  Assassin: ['Death Strike', 'Lethal Exploit', 'Ranged Ambush', 'Shadow Walk'],
+  Barbarian: ['Berserk', 'Brawl', 'Feat of Strength', 'Grapple'],
+  Mage: ['Arcane Finesse', 'Dweomers', 'Intangible Threat', 'Path Mastery'],
+  Mystic: ['Iron Mind', 'Path Mastery', 'Premonition', 'Psychic Powers'],
+  Rogue: ['Backstab', 'Evasion', 'Roguish Charm', 'Stealth'],
+  Theurgist: ['Divine Healing', 'Path Mastery', 'Spiritual Smite', 'Supernatural Intervention'],
+  Warrior: ['Battle Savvy', 'Maneuvers', 'Stunning Reversal', 'Sunder Foe']
+};
+
+export const raceFlaws: Record<string, string[]> = {
+  Gnome: ['Restriction: small weapons only'],
+  Halfling: ['Restriction: small weapons only'],
+  'Half-Orc': ['Ugliness']
+};
+
+export const startingEquipment: Record<string, string[]> = {
+  common: ['Set of ordinary clothes', 'Purse of 5 gold coins', 'Backpack', 'Small dagger', "Week's rations", 'Waterskin', 'Tinderbox', "50' rope", 'Iron spikes', 'Small hammer', "6' traveling staff or 10' pole", 'Hooded lantern and 2 oil flasks or d4+1 torches'],
+  Adept: ['Book of knowledge (area of expertise)'],
+  Assassin: ['Assassin hood, jacket, cape, robe, or tunic'],
+  Barbarian: ['Garments of woven wool or linen', 'Tunic', 'Overcoat or cloak'],
+  Mage: ['Spellbook', 'Staff or focus item'],
+  Mystic: ['Robes or shawl', 'Cloak', 'Armor up to leather'],
+  Rogue: ["Set of thieves' tools", 'Light armor (up to leather)', 'One weapon'],
+  Theurgist: ['Prayer book', 'Holy relic or symbol', 'Focus item', 'Armor up to chain'],
+  Warrior: ['One weapon of choice', 'Armor up to chain', 'Small to large shield', 'Steed']
+};
+
+export const stepCost: Record<DieRank, number> = { d4: 6, d6: 8, d8: 10, d10: 12, d12: Infinity } as const;
+export const focusStepCost = 4;
+
+export const classAxes: Record<string, string[]> = {
+  Warrior: ['Prowess', 'Melee', 'Strength', 'Fortitude', 'Endurance', 'Threat', 'Agility', 'Might'],
+  Barbarian: ['Prowess', 'Melee', 'Strength', 'Fortitude', 'Endurance', 'Ferocity', 'Might', 'Vitality'],
+  Rogue: ['Prowess', 'Agility', 'Competence', 'Adroitness', 'Perception', 'Skulduggery', 'Cleverness', 'Speed'],
+  Assassin: ['Prowess', 'Agility', 'Melee', 'Competence', 'Adroitness', 'Finesse', 'Speed', 'Perception'],
+  Mage: ['Competence', 'Expertise', 'Wizardry', 'Fortitude', 'Willpower', 'Resistance', 'Perception'],
+  Mystic: ['Fortitude', 'Willpower', 'Competence', 'Expertise', 'Endurance', 'Prowess', 'Melee', 'Resilience', 'Vitality'],
+  Adept: ['Competence', 'Expertise', 'Adroitness', 'Perception', 'Cleverness', 'Wizardry', 'Perspicacity'],
+  Theurgist: ['Competence', 'Expertise', 'Theurgy', 'Fortitude', 'Willpower', 'Endurance', 'Courage']
+};
+
+export interface Character {
+  race: string;
+  class: string;
+  level: number;
+  abilities: Record<string, string>;
+  specialties: Record<string, Record<string, string>>;
+  focuses: Record<string, Record<string, string>>;
+  masteryDie: string;
+  advantages: string[];
+  flaws: string[];
+  classFeats: string[];
+  equipment: string[];
+  actions: Record<string, string>;
+  pools: {
+    active: number;
+    passive: number;
+    spirit: number;
+  };
+}
+
+export const idx = (r: string) => dieRanks.indexOf(r as DieRank);
+export const mv = (r: string) => (r && r.startsWith('d') ? parseInt(r.slice(1), 10) : 0);
+export const fnum = (v: string | number) => (v ? parseInt(String(v).replace('+', ''), 10) : 0);
+
+export function deepCloneCharacter<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function applyMinima(ch: Character, minima: Record<string, string>) {
+  for (const [k, v] of Object.entries(minima || {})) {
+    if ((abilities as readonly string[]).includes(k)) {
+      if (idx(v) > idx(ch.abilities[k])) ch.abilities[k] = v;
+    } else {
+      const parentA = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(k));
+      const parentS = Object.keys(foci).find(s => (foci as Record<string, string[]>)[s].includes(k));
+      if (parentA) {
+        if (idx(v) > idx(ch.specialties[parentA][k])) ch.specialties[parentA][k] = v;
+      } else if (parentS) {
+        const pa = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(parentS));
+        if (pa && fnum(v) > fnum(ch.focuses[pa][k])) ch.focuses[pa][k] = `+${fnum(v)}`;
+      }
+    }
+  }
+}
+
+const buildWeights = (klass: string, style: string) => {
+  const axis = classAxes[klass as keyof typeof classAxes] || [];
+  const w: Record<string, number> = {};
+  axis.forEach((k, i) => (w[k] = style === 'specialist' ? 100 - i * 4 : style === 'balanced' ? 60 - i * 3 : 80 - i * 3));
+  if (style === 'balanced') {
+    w['Competence'] = (w['Competence'] || 30) + 20;
+    w['Fortitude'] = (w['Fortitude'] || 30) + 20;
+    ['Endurance', 'Strength', 'Willpower', 'Agility'].forEach(k => (w[k] = (w[k] || 20) + 10));
+  }
+  return w;
+};
+
+const canUpgrade = (_ch: Character, _key: string, _kind: string, _level: number, _style: string, enforceSoftcaps: boolean) => {
+  if (!enforceSoftcaps) return true;
+  return true;
+};
+
+export function spendCP(
+  ch: Character,
+  cpBudget: { value: number },
+  style: string,
+  level: number,
+  npcMode: boolean,
+  enforceSoftcaps: boolean
+) {
+  const weights = buildWeights(ch.class, style);
+  const tryUpgrade = (key: string) => {
+    if ((abilities as readonly string[]).includes(key)) {
+      const cur = ch.abilities[key];
+      if (cur === 'd12') return false;
+      if (!canUpgrade(ch, key, 'ability', level, style, enforceSoftcaps)) return false;
+      const cost = stepCost[cur as DieRank];
+      if (cpBudget.value < cost) return false;
+      ch.abilities[key] = dieRanks[idx(cur) + 1] as DieRank;
+      cpBudget.value -= cost;
+      return true;
+    }
+    const pa = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(key));
+    if (pa) {
+      const cur = ch.specialties[pa][key];
+      if (cur === 'd12') return false;
+      if (!canUpgrade(ch, key, 'spec', level, style, enforceSoftcaps)) return false;
+      const cost = stepCost[cur as DieRank];
+      if (cpBudget.value < cost) return false;
+      ch.specialties[pa][key] = dieRanks[idx(cur) + 1] as DieRank;
+      cpBudget.value -= cost;
+      return true;
+    }
+    const ps = Object.keys(foci).find(s => (foci as Record<string, string[]>)[s].includes(key));
+    if (ps) {
+      const pa2 = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(ps));
+      if (pa2) {
+        const val = fnum(ch.focuses[pa2][key]);
+        if (val >= 5) return false;
+        if (cpBudget.value < focusStepCost) return false;
+        ch.focuses[pa2][key] = `+${val + 1}`;
+        cpBudget.value -= focusStepCost;
+        return true;
+      }
+    }
+    return false;
+  };
+  const keys = [...new Set([...abilities, ...Object.values(specs).flat(), ...Object.values(foci).flat()])];
+  let safety = 0;
+  while (cpBudget.value > 0 && safety < 5000) {
+    safety++;
+    const sorted = keys.slice().sort((a, b) => (weights[b] || 10) - (weights[a] || 10));
+    let upgraded = false;
+    for (const k of sorted) {
+      if (tryUpgrade(k)) {
+        upgraded = true;
+        break;
+      }
+    }
+    if (!upgraded) break;
+  }
+}
+
+export function computePools(ch: Character) {
+  const AD = mv(ch.abilities.Prowess) + mv(ch.specialties.Prowess.Agility) + mv(ch.specialties.Prowess.Melee);
+  const PD = mv(ch.abilities.Fortitude) + mv(ch.specialties.Fortitude.Endurance) + mv(ch.specialties.Fortitude.Strength);
+  const SP = mv(ch.abilities.Competence) + mv(ch.specialties.Fortitude.Willpower);
+  return { active: AD, passive: PD, spirit: SP };
+}
+
+export function weaknessReport(ch: Character) {
+  const { active, passive, spirit } = computePools(ch);
+  const flags: string[] = [];
+  if (spirit <= 12) flags.push('Low Spirit Points (mental/arcane pressure will hurt).');
+  if (active < 24) flags.push('Low Active DP (poor agility/parry).');
+  if (passive < 24) flags.push('Low Passive DP (fragile to heavy blows).');
+  if (idx(ch.abilities.Competence) <= 1) flags.push('Low Competence (poor perception/social/planning).');
+  if (idx(ch.specialties.Competence.Perception) <= 1) flags.push('Low Perception branch (traps/ambush risk).');
+  if (idx(ch.specialties.Fortitude.Willpower) <= 1) flags.push('Low Willpower (charms/fear/illusions).');
+  if (idx(ch.specialties.Prowess.Precision) <= 1) flags.push('Weak ranged capability.');
+  return flags;
+}
+
+export function calculateCPSpent(finalChar: Character, baseChar: Character, iconic: boolean) {
+  const spent = { abilities: 0, specialties: 0, focuses: 0, advantages: 0, total: 0 };
+  spent.advantages = iconic ? 4 : 0;
+
+  for (const ab of abilities) {
+    const abilityKey = ab as keyof typeof specs;
+    const baseRankIndex = idx(baseChar.abilities[ab]);
+    const finalRankIndex = idx(finalChar.abilities[ab]);
+    for (let i = baseRankIndex; i < finalRankIndex; i++) {
+      spent.abilities += stepCost[dieRanks[i] as DieRank];
+    }
+
+    for (const sp of specs[abilityKey]) {
+      const baseSpecIndex = idx(baseChar.specialties[ab][sp]);
+      const finalSpecIndex = idx(finalChar.specialties[ab][sp]);
+      for (let i = baseSpecIndex; i < finalSpecIndex; i++) {
+        spent.specialties += stepCost[dieRanks[i] as DieRank];
+      }
+    }
+
+    Object.keys(foci).forEach(specKey => {
+      if (specs[abilityKey].includes(specKey)) {
+        foci[specKey as keyof typeof foci].forEach(focusKey => {
+          const baseFocusValue = fnum(baseChar.focuses[ab][focusKey]);
+          const finalFocusValue = fnum(finalChar.focuses[ab][focusKey]);
+          spent.focuses += (finalFocusValue - baseFocusValue) * focusStepCost;
+        });
+      }
+    });
+  }
+
+  spent.total = 10 + spent.abilities + spent.specialties + spent.focuses + spent.advantages;
+  return spent;
+}
+
+export function getAdvantages(race: string, klass: string) {
+  const raceAdv = allAdvantages[race as keyof typeof allAdvantages] || [];
+  const classAdv = allAdvantages[klass as keyof typeof allAdvantages] || [];
+  return [...new Set([...raceAdv, ...classAdv])];
+}
+
+export function getEquipment(klass: string) {
+  return [...startingEquipment.common, ...(startingEquipment[klass as keyof typeof startingEquipment] || [])];
+}
+
+export function createCharacterShell(race: string, klass: string, level: number) {
+  const ch: Character = {
+    race,
+    class: klass,
+    level,
+    abilities: {},
+    specialties: {},
+    focuses: {},
+    masteryDie: '',
+    advantages: [],
+    flaws: [],
+    classFeats: [],
+    equipment: [],
+    actions: {},
+    pools: { active: 0, passive: 0, spirit: 0 }
+  };
+
+  (abilities as readonly string[]).forEach(a => {
+    const abilityKey = a as keyof typeof specs;
+    ch.abilities[a] = 'd4';
+    ch.specialties[a] = {};
+    ch.focuses[a] = {};
+    specs[abilityKey].forEach(s => {
+      ch.specialties[a][s] = 'd4';
+      foci[s as keyof typeof foci].forEach(fx => {
+        ch.focuses[a][fx] = '+0';
+      });
+    });
+  });
+
+  const baseCharacter = deepCloneCharacter(ch);
+  applyMinima(baseCharacter, raceMinima[race] || {});
+  applyMinima(baseCharacter, classMinima[klass] || {});
+
+  const workingCharacter = deepCloneCharacter(baseCharacter);
+  workingCharacter.masteryDie = levelInfo[level - 1]?.masteryDie || 'd4';
+  workingCharacter.pools = computePools(workingCharacter);
+  workingCharacter.advantages = getAdvantages(race, klass);
+  workingCharacter.flaws = raceFlaws[race as keyof typeof raceFlaws] || [];
+  workingCharacter.classFeats = classFeats[klass as keyof typeof classFeats] || [];
+  workingCharacter.equipment = getEquipment(klass);
+  updateActionSummaries(workingCharacter);
+
+  return { character: workingCharacter, baseCharacter };
+}
+
+export function updateActionSummaries(ch: Character) {
+  const wizardry = ch.focuses?.Competence ? fnum(ch.focuses.Competence.Wizardry) : 0;
+  const theurgy = ch.focuses?.Competence ? fnum(ch.focuses.Competence.Theurgy) : 0;
+  ch.actions = {
+    meleeAttack:
+      `${ch.abilities.Prowess} + ${ch.specialties.Prowess.Melee}` +
+      (fnum(ch.focuses.Prowess.Threat) ? ` + Threat +${fnum(ch.focuses.Prowess.Threat)}` : ''),
+    rangedAttack:
+      `${ch.abilities.Prowess} + ${ch.specialties.Prowess.Precision}` +
+      (fnum(ch.focuses.Prowess['Ranged Threat']) ? ` + Ranged Threat +${fnum(ch.focuses.Prowess['Ranged Threat'])}` : ''),
+    perceptionCheck:
+      `${ch.abilities.Competence} + ${ch.specialties.Competence.Perception}` +
+      (fnum(ch.focuses.Competence.Perspicacity) ? ` + Perspicacity +${fnum(ch.focuses.Competence.Perspicacity)}` : ''),
+    magicAttack: casterClasses.includes(ch.class as (typeof casterClasses)[number])
+      ? `${ch.abilities.Competence} + ${ch.specialties.Competence.Expertise} + ${
+          wizardry ? `Wizardry +${wizardry}` : theurgy ? `Theurgy +${theurgy}` : '(path focus 0)'
+        }`
+      : '—'
+  };
+  ch.pools = computePools(ch);
+}
+
+export function updateDerivedCharacterData(ch: Character) {
+  ch.masteryDie = levelInfo[ch.level - 1]?.masteryDie || 'd4';
+  ch.advantages = getAdvantages(ch.race, ch.class);
+  ch.flaws = raceFlaws[ch.race as keyof typeof raceFlaws] || [];
+  ch.classFeats = classFeats[ch.class as keyof typeof classFeats] || [];
+  ch.equipment = getEquipment(ch.class);
+  updateActionSummaries(ch);
+}


### PR DESCRIPTION
## Summary
- extract shared character build data and helper utilities from the generator into `src/utils/characterBuild.ts`
- add a new ManualCharacterBuilder experience with CP budgeting, validation, and roster save flow
- surface the manual builder in navigation, add a dedicated page route, and document usage in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde43cfe18832fb11678652a6b035a