### PR TITLE
Fix type safety issues in character builders

### DIFF
--- a/src/components/CharacterGenerator.tsx
+++ b/src/components/CharacterGenerator.tsx
@@ -9,6 +9,7 @@ import {
   createCharacterShell,
   fnum,
   foci,
+  levels,
   magicPathsByClass,
   races,
   specs,
@@ -38,6 +39,11 @@ import { SavedCharacter, PartyFolder, PartyMembership } from '../types/party';
 function showAlert(message: string) {
   alert(message);
 }
+
+const isCasterClass = (
+  klass: Character['class']
+): klass is (typeof casterClasses)[number] =>
+  (casterClasses as readonly string[]).includes(klass);
 
 export default function CharacterGenerator() {
   const [race, setRace] = useState('');
@@ -150,7 +156,7 @@ export default function CharacterGenerator() {
       }).join(', ');
       md += `**${a} ${ch.abilities[a]}** → ${sp}.\n`;
     }
-    md += `\n### Actions\n- **Melee Attack:** ${ch.actions.meleeAttack}\n- **Ranged Attack:** ${ch.actions.rangedAttack}\n- **Perception Check:** ${ch.actions.perceptionCheck}\n` + (casterClasses.includes(ch.class) ? `- **Magic Attack:** ${ch.actions.magicAttack}\n\n` : '\n');
+    md += `\n### Actions\n- **Melee Attack:** ${ch.actions.meleeAttack}\n- **Ranged Attack:** ${ch.actions.rangedAttack}\n- **Perception Check:** ${ch.actions.perceptionCheck}\n` + (isCasterClass(ch.class) ? `- **Magic Attack:** ${ch.actions.magicAttack}\n\n` : '\n');
 
     md += `### Advantages & Flaws\n**Advantages:**\n${ch.advantages.map(a => `- ${a}`).join('\n')}\n\n**Flaws:**\n${ch.flaws.length ? ch.flaws.map(f => `- ${f}`).join('\n') : '- None'}\n\n`;
     md += `### Class Feats\n${ch.classFeats.map(f => `- ${f}`).join('\n')}\n\n`;
@@ -518,7 +524,7 @@ export default function CharacterGenerator() {
                   <li><strong>Melee Attack:</strong> {character.actions.meleeAttack}</li>
                   <li><strong>Ranged Attack:</strong> {character.actions.rangedAttack}</li>
                   <li><strong>Perception Check:</strong> {character.actions.perceptionCheck}</li>
-                  {casterClasses.includes(character.class) && (
+                  {isCasterClass(character.class) && (
                     <li><strong>Magic Attack:</strong> {character.actions.magicAttack}</li>
                   )}
                 </ul>

--- a/src/components/ManualCharacterBuilder.tsx
+++ b/src/components/ManualCharacterBuilder.tsx
@@ -16,7 +16,8 @@ import {
   updateDerivedCharacterData,
   weaknessReport,
   mv,
-  type Character
+  type Character,
+  type DieRank
 } from '../utils/characterBuild';
 import {
   saveCharacter,
@@ -105,7 +106,7 @@ export default function ManualCharacterBuilder() {
     setCharacter(prev => {
       if (!prev) return prev;
       const next = deepCloneCharacter(prev);
-      (next as Record<string, unknown>).magicPath = selectedMagicPath;
+      next.magicPath = selectedMagicPath;
       return next;
     });
   }, [selectedMagicPath]);
@@ -121,8 +122,8 @@ export default function ManualCharacterBuilder() {
 
   const adjustAbility = (ability: string, delta: number) => {
     if (!character || !baseCharacter) return;
-    const currentIndex = dieRanks.indexOf(character.abilities[ability]);
-    const minIndex = dieRanks.indexOf(baseCharacter.abilities[ability]);
+    const currentIndex = dieRanks.indexOf(character.abilities[ability] as DieRank);
+    const minIndex = dieRanks.indexOf(baseCharacter.abilities[ability] as DieRank);
     const nextIndex = currentIndex + delta;
     if (nextIndex < minIndex || nextIndex < 0 || nextIndex >= dieRanks.length) return;
     applyCharacterUpdate(draft => {
@@ -132,8 +133,8 @@ export default function ManualCharacterBuilder() {
 
   const adjustSpecialty = (ability: string, specialty: string, delta: number) => {
     if (!character || !baseCharacter) return;
-    const currentIndex = dieRanks.indexOf(character.specialties[ability][specialty]);
-    const minIndex = dieRanks.indexOf(baseCharacter.specialties[ability][specialty]);
+    const currentIndex = dieRanks.indexOf(character.specialties[ability][specialty] as DieRank);
+    const minIndex = dieRanks.indexOf(baseCharacter.specialties[ability][specialty] as DieRank);
     const nextIndex = currentIndex + delta;
     if (nextIndex < minIndex || nextIndex < 0 || nextIndex >= dieRanks.length) return;
     applyCharacterUpdate(draft => {
@@ -251,8 +252,8 @@ export default function ManualCharacterBuilder() {
 
   const handleRandomName = () => {
     if (!character) return;
-    const randomName = generateRandomName(character.race, characterGender, nameCulture);
-    setPcName(randomName);
+    const randomName = generateRandomName(characterGender, nameCulture, true, character.race);
+    setPcName(`${randomName.firstName}${randomName.familyName ? ` ${randomName.familyName}` : ''}`);
   };
 
   return (

--- a/src/utils/characterBuild.ts
+++ b/src/utils/characterBuild.ts
@@ -141,6 +141,7 @@ export interface Character {
   flaws: string[];
   classFeats: string[];
   equipment: string[];
+  magicPath?: string;
   actions: Record<string, string>;
   pools: {
     active: number;
@@ -162,12 +163,12 @@ export function applyMinima(ch: Character, minima: Record<string, string>) {
     if ((abilities as readonly string[]).includes(k)) {
       if (idx(v) > idx(ch.abilities[k])) ch.abilities[k] = v;
     } else {
-      const parentA = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(k));
-      const parentS = Object.keys(foci).find(s => (foci as Record<string, string[]>)[s].includes(k));
+      const parentA = Object.keys(specs).find(a => (specs as Record<string, readonly string[]>)[a].includes(k));
+      const parentS = Object.keys(foci).find(s => (foci as Record<string, readonly string[]>)[s].includes(k));
       if (parentA) {
         if (idx(v) > idx(ch.specialties[parentA][k])) ch.specialties[parentA][k] = v;
       } else if (parentS) {
-        const pa = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(parentS));
+        const pa = Object.keys(specs).find(a => (specs as Record<string, readonly string[]>)[a].includes(parentS));
         if (pa && fnum(v) > fnum(ch.focuses[pa][k])) ch.focuses[pa][k] = `+${fnum(v)}`;
       }
     }
@@ -211,7 +212,7 @@ export function spendCP(
       cpBudget.value -= cost;
       return true;
     }
-    const pa = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(key));
+    const pa = Object.keys(specs).find(a => (specs as Record<string, readonly string[]>)[a].includes(key));
     if (pa) {
       const cur = ch.specialties[pa][key];
       if (cur === 'd12') return false;
@@ -222,9 +223,9 @@ export function spendCP(
       cpBudget.value -= cost;
       return true;
     }
-    const ps = Object.keys(foci).find(s => (foci as Record<string, string[]>)[s].includes(key));
+    const ps = Object.keys(foci).find(s => (foci as Record<string, readonly string[]>)[s].includes(key));
     if (ps) {
-      const pa2 = Object.keys(specs).find(a => (specs as Record<string, string[]>)[a].includes(ps));
+      const pa2 = Object.keys(specs).find(a => (specs as Record<string, readonly string[]>)[a].includes(ps));
       if (pa2) {
         const val = fnum(ch.focuses[pa2][key]);
         if (val >= 5) return false;
@@ -292,15 +293,14 @@ export function calculateCPSpent(finalChar: Character, baseChar: Character, icon
       }
     }
 
-    Object.keys(foci).forEach(specKey => {
-      if (specs[abilityKey].includes(specKey)) {
-        foci[specKey as keyof typeof foci].forEach(focusKey => {
-          const baseFocusValue = fnum(baseChar.focuses[ab][focusKey]);
-          const finalFocusValue = fnum(finalChar.focuses[ab][focusKey]);
-          spent.focuses += (finalFocusValue - baseFocusValue) * focusStepCost;
-        });
-      }
-    });
+    for (const specKey of specs[abilityKey]) {
+      const focusKeys = foci[specKey as keyof typeof foci];
+      focusKeys.forEach(focusKey => {
+        const baseFocusValue = fnum(baseChar.focuses[ab][focusKey]);
+        const finalFocusValue = fnum(finalChar.focuses[ab][focusKey]);
+        spent.focuses += (finalFocusValue - baseFocusValue) * focusStepCost;
+      });
+    }
   }
 
   spent.total = 10 + spent.abilities + spent.specialties + spent.focuses + spent.advantages;


### PR DESCRIPTION
## Summary
- add a dedicated caster class type guard and wire up shared level options in the character generator
- tighten manual builder typings, including magic path handling and random name generation
- update character utilities for optional magic paths and readonly spec/focus lookups to satisfy strict builds

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddfaa781f4832facf02fb7cb9f759f