### PR TITLE
Fix manual builder cost exports and caster markdown

### DIFF
--- a/src/components/CharacterGenerator.tsx
+++ b/src/components/CharacterGenerator.tsx
@@ -153,7 +153,7 @@ export default function CharacterGenerator() {
       }).join(', ');
       md += `**${a} ${ch.abilities[a]}** → ${sp}.\n`;
     }
-    md += `\n### Actions\n- **Melee Attack:** ${ch.actions.meleeAttack}\n- **Ranged Attack:** ${ch.actions.rangedAttack}\n- **Perception Check:** ${ch.actions.perceptionCheck}\n` + (casterClasses.includes(ch.class) ? `- **Magic Attack:** ${ch.actions.magicAttack}\n\n` : '\n');
+    md += `\n### Actions\n- **Melee Attack:** ${ch.actions.meleeAttack}\n- **Ranged Attack:** ${ch.actions.rangedAttack}\n- **Perception Check:** ${ch.actions.perceptionCheck}\n` + ((casterClasses as readonly string[]).includes(ch.class) ? `- **Magic Attack:** ${ch.actions.magicAttack}\n\n` : '\n');
 
     md += `### Advantages & Flaws\n**Advantages:**\n${ch.advantages.map(a => `- ${a}`).join('\n')}\n\n**Flaws:**\n${ch.flaws.length ? ch.flaws.map(f => `- ${f}`).join('\n') : '- None'}\n\n`;
     md += `### Class Feats\n${ch.classFeats.map(f => `- ${f}`).join('\n')}\n\n`;

--- a/src/utils/characterBuild.ts
+++ b/src/utils/characterBuild.ts
@@ -27,6 +27,9 @@ export type { Ability, DieRank, Specialty, Focus };
 export const races = raceNames;
 export const classes = classNames;
 
+export const stepCost = costToRankUpDie;
+export const focusStepCost = costToRankUpFocus;
+
 export interface Character {
   race: RaceName;
   class: ClassName;

--- a/src/utils/characterUtils.ts
+++ b/src/utils/characterUtils.ts
@@ -2,7 +2,6 @@
 import {
   abilities,
   buildPhilosophies,
-  casterClasses,
   classNames,
   classes,
   costToRankUpDie,


### PR DESCRIPTION
## Summary
- expose the die and focus step costs from the character build utilities for manual builder use
- ensure the character generator markdown treats caster classes without narrowing issues
- clean up an unused caster class import in character utilities

## Testing
- npm run build *(fails: existing parse error in MonsterGenerator.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68de015f4358832f898b2b007eaee503