### PR TITLE
Update generator labels and add CP tally overlay

### DIFF
--- a/src/app/gm-tools/page.tsx
+++ b/src/app/gm-tools/page.tsx
@@ -51,7 +51,11 @@ const TOOL_SECTIONS: ToolSection[] = [
     links: [
       {
         href: '/character-generator?from=gm-tools',
-        label: 'Character Generator →'
+        label: 'Random PC Generator →'
+      },
+      {
+        href: '/character-builder?from=gm-tools',
+        label: 'Standard Character Generator →'
       },
       {
         href: '/roster?from=gm-tools',

--- a/src/app/player-tools/page.tsx
+++ b/src/app/player-tools/page.tsx
@@ -6,8 +6,8 @@ const playerResources = [
     description:
       'Build and maintain your Eldritch heroes with streamlined creation tools and shared rosters for your party.',
     links: [
-      { href: '/character-generator?from=player-tools', label: 'Character Generator →' },
-      { href: '/character-builder?from=player-tools', label: 'Manual Builder →' },
+      { href: '/character-generator?from=player-tools', label: 'Random PC Generator →' },
+      { href: '/character-builder?from=player-tools', label: 'Standard Character Generator →' },
       { href: '/roster?from=player-tools', label: 'Character Roster →' }
     ]
   },

--- a/src/app/roster/page.tsx
+++ b/src/app/roster/page.tsx
@@ -152,8 +152,8 @@ function RosterContent() {
         <div className="bg-white rounded-lg shadow-lg p-6 mb-8">
           <h2 className="text-2xl font-bold mb-4">No Characters Created Yet</h2>
           <p className="text-gray-600 mb-4">
-            You haven&apos;t created any player characters yet. Use the Character Generator to create
-            characters that will appear in this roster.
+            You haven&apos;t created any player characters yet. Use the Random PC Generator or the Standard Character Generator to
+            create heroes that will appear in this roster.
           </p>
           <div className="bg-gray-50 p-4 rounded">
             <p className="text-sm text-gray-600">

--- a/src/components/CharacterGenerator.tsx
+++ b/src/components/CharacterGenerator.tsx
@@ -309,7 +309,7 @@ export default function CharacterGenerator() {
       <div className="mx-auto max-w-6xl p-4 sm:p-6 lg:p-8">
         <header className="mb-6 sm:mb-8 text-center">
           <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight">Eldritch RPG 2nd Edition</h1>
-          <p className="text-gray-600">Character Generator — <span className="font-semibold">Balanced · Specialist · Rookie</span></p>
+          <p className="text-gray-600">Random PC Generator — <span className="font-semibold">Balanced · Specialist · Rookie</span></p>
         </header>
 
         {/* Controls */}

--- a/src/components/ManualCharacterBuilder.tsx
+++ b/src/components/ManualCharacterBuilder.tsx
@@ -295,9 +295,28 @@ export default function ManualCharacterBuilder() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-10">
+      {character && (
+        <div className="fixed bottom-4 left-4 right-4 sm:left-auto sm:right-6 sm:w-80 z-40">
+          <div className="bg-white/95 backdrop-blur border border-gray-200 shadow-xl rounded-2xl p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="text-xs uppercase tracking-wide text-gray-500">CP Budget</div>
+              <div className="font-semibold text-gray-900">{cpBudget}</div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-xs uppercase tracking-wide text-gray-500">CP Spent</div>
+              <div className="font-semibold text-gray-900">{cpSpentFromBudget}</div>
+            </div>
+            <div className={`flex items-center justify-between ${cpRemaining < 0 ? 'text-red-700' : 'text-green-700'}`}>
+              <div className="text-xs uppercase tracking-wide">CP Remaining</div>
+              <div className="text-lg font-extrabold">{cpRemaining}</div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold">Manual Character Builder</h1>
+          <h1 className="text-3xl font-bold">Standard Character Generator</h1>
           <p className="text-sm text-gray-600">Plan every CP by hand to create bespoke heroes. Choose race, class, and level, then allocate abilities, specialties, and focuses within your budget.</p>
         </div>
         <button


### PR DESCRIPTION
## Summary
- rename the random generator to “Random PC Generator” and the manual flow to “Standard Character Generator” across headings and navigation
- add a floating CP budget/spent/remaining overlay to keep the manual builder totals visible while scrolling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb4383524832fb19d73643cb021f1)